### PR TITLE
Refactor views: Login, Register, SearchResults, Navbar and more

### DIFF
--- a/backend/src/data-source.ts
+++ b/backend/src/data-source.ts
@@ -1,6 +1,7 @@
 import "reflect-metadata"
 import { DataSource } from "typeorm"
 import { User } from "./entities/User"
+import { Review } from "./entities/Review"
 
 export const AppDataSource = new DataSource({
     type: "postgres",
@@ -11,7 +12,7 @@ export const AppDataSource = new DataSource({
     database: "test",
     synchronize: true,
     logging: false,
-    entities: [User],
+    entities: [User, Review],
     migrations: [],
     subscribers: [],
 })

--- a/backend/src/entities/Review.ts
+++ b/backend/src/entities/Review.ts
@@ -1,0 +1,24 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, ManyToOne } from "typeorm"
+import { User } from "./User"
+
+@Entity()
+export class Review {
+
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    professionalId: number
+
+    @Column()
+    clientName: string
+
+    @Column({ type: "int" })
+    rating: number  // 1-5
+
+    @Column({ type: "text" })
+    comment: string
+
+    @CreateDateColumn()
+    createdAt: Date
+}

--- a/backend/src/entities/User.ts
+++ b/backend/src/entities/User.ts
@@ -40,6 +40,15 @@ export class User {
     @Column({ type: "varchar", default: Role.CLIENT })
     role: Role
 
+    @Column({ nullable: true })
+    specialty: string
+
+    @Column({ nullable: true })
+    yearsOfExperience: number
+
+    @Column({ nullable: true })
+    registrationNumber: number
+
     constructor(
         firstName: string,
         lastName: string,

--- a/backend/src/routes/routes.ts
+++ b/backend/src/routes/routes.ts
@@ -167,7 +167,7 @@ router.get("/search", async (req, res) => {
             where: [
                 { role: Role.PROFESSIONAL, firstName: Like(`%${q}%`) },
                 { role: Role.PROFESSIONAL, lastName: Like(`%${q}%`) },
-                { role: Role.PROFESSIONAL, email: Like(`%${q}%`) },
+                { role: Role.PROFESSIONAL, specialty: Like(`%${q}%`) },
                 { role: Role.PROFESSIONAL, address: Like(`%${q}%`) },
             ]
         })

--- a/backend/src/routes/routes.ts
+++ b/backend/src/routes/routes.ts
@@ -1,6 +1,7 @@
 import { Router } from "express"
 import { AppDataSource } from "../data-source"
 import { User } from "../entities/User"
+import { Review } from "../entities/Review"
 import { Role } from "../entities/Role"
 import { authorize } from "../middleware/authorize"
 import { signToken } from "../utils/jwt"
@@ -173,6 +174,61 @@ router.get("/search", async (req, res) => {
         })
 
         return res.json({ results: professionals })
+    } catch (error) {
+        return res.status(400).json({ message: error.message })
+    }
+})
+
+// Perfil público de un profesional por ID
+router.get("/professionals/:id", async (req, res) => {
+    try {
+        const userRepository = AppDataSource.getRepository(User)
+        const professional = await userRepository.findOne({
+            where: { id: Number(req.params.id), role: Role.PROFESSIONAL }
+        })
+        if (!professional) {
+            return res.status(404).json({ message: "Profesional no encontrado." })
+        }
+        return res.json({ professional })
+    } catch (error) {
+        return res.status(400).json({ message: error.message })
+    }
+})
+
+// Obtener últimas 3 reseñas de un profesional
+router.get("/professionals/:id/reviews", async (req, res) => {
+    try {
+        const reviewRepository = AppDataSource.getRepository(Review)
+        const reviews = await reviewRepository.find({
+            where: { professionalId: Number(req.params.id) },
+            order: { createdAt: "DESC" },
+            take: 3
+        })
+        return res.json({ reviews })
+    } catch (error) {
+        return res.status(400).json({ message: error.message })
+    }
+})
+
+// Crear una reseña para un profesional
+router.post("/professionals/:id/reviews", async (req, res) => {
+    try {
+        const { clientName, rating, comment } = req.body
+        if (!clientName || !rating || !comment) {
+            return res.status(400).json({ message: "Todos los campos son obligatorios." })
+        }
+        if (rating < 1 || rating > 5) {
+            return res.status(400).json({ message: "La calificación debe ser entre 1 y 5." })
+        }
+        const reviewRepository = AppDataSource.getRepository(Review)
+        const review = reviewRepository.create({
+            professionalId: Number(req.params.id),
+            clientName,
+            rating,
+            comment
+        })
+        await reviewRepository.save(review)
+        return res.status(201).json({ message: "Reseña enviada correctamente.", review })
     } catch (error) {
         return res.status(400).json({ message: error.message })
     }

--- a/backend/src/routes/routes.ts
+++ b/backend/src/routes/routes.ts
@@ -113,7 +113,7 @@ router.post("/login-client", async (req, res) => {
         }
 
         const userRepository = AppDataSource.getRepository(User)
-        const user = await userRepository.findOne({ where: { email, role: Role.CLIENT } })
+        const user = await userRepository.findOne({ where: [{ email, role: Role.CLIENT }, { email, role: Role.ADMIN }] })
 
         if (!user) {
             return res.status(404).json({ message: "Cliente no encontrado." })
@@ -138,7 +138,7 @@ router.post("/login-professional", async (req, res) => {
         }
 
         const userRepository = AppDataSource.getRepository(User)
-        const user = await userRepository.findOne({ where: { email, role: Role.PROFESSIONAL } })
+        const user = await userRepository.findOne({ where: [{ email, role: Role.PROFESSIONAL }, { email, role: Role.ADMIN }] })
 
         if (!user) {
             return res.status(404).json({ message: "Profesional no encontrado." })

--- a/backend/src/routes/routes.ts
+++ b/backend/src/routes/routes.ts
@@ -4,7 +4,7 @@ import { User } from "../entities/User"
 import { Role } from "../entities/Role"
 import { authorize } from "../middleware/authorize"
 import { signToken } from "../utils/jwt"
-import { Like } from "typeorm"
+import { ILike } from "typeorm"
 
 const router = Router()
 
@@ -165,10 +165,10 @@ router.get("/search", async (req, res) => {
         const userRepository = AppDataSource.getRepository(User)
         const professionals = await userRepository.find({
             where: [
-                { role: Role.PROFESSIONAL, firstName: Like(`%${q}%`) },
-                { role: Role.PROFESSIONAL, lastName: Like(`%${q}%`) },
-                { role: Role.PROFESSIONAL, specialty: Like(`%${q}%`) },
-                { role: Role.PROFESSIONAL, address: Like(`%${q}%`) },
+                { role: Role.PROFESSIONAL, firstName: ILike(`%${q}%`) },
+                { role: Role.PROFESSIONAL, lastName: ILike(`%${q}%`) },
+                { role: Role.PROFESSIONAL, specialty: ILike(`%${q}%`) },
+                { role: Role.PROFESSIONAL, address: ILike(`%${q}%`) },
             ]
         })
 

--- a/backend/src/seed.ts
+++ b/backend/src/seed.ts
@@ -1,64 +1,172 @@
 import { AppDataSource } from "./data-source"
 import { User } from "./entities/User"
+import { Review } from "./entities/Review"
 import { Role } from "./entities/Role"
 
+const reviewComments = [
+    { rating: 5, comment: "Excelente trabajo, muy profesional y puntual. Lo recomiendo totalmente." },
+    { rating: 5, comment: "Resolvió el problema rápido y a buen precio. Volvería a contratarlo." },
+    { rating: 4, comment: "Buen trabajo, cumplió con lo acordado. Muy amable y ordenado." },
+    { rating: 5, comment: "Muy buena atención y calidad de trabajo. Quedé muy conforme." },
+    { rating: 4, comment: "Llegó a horario, explicó bien lo que hizo y el precio fue justo." },
+    { rating: 3, comment: "El trabajo quedó bien pero tardó más de lo esperado." },
+    { rating: 5, comment: "Profesional de confianza. Ya lo llamé varias veces y siempre excelente." },
+    { rating: 4, comment: "Buen servicio, resolvió el problema sin inconvenientes." },
+    { rating: 5, comment: "Muy prolijo y eficiente. Dejó todo limpio al terminar." },
+    { rating: 4, comment: "Muy bien, cumplió en tiempo y forma. Lo recomiendo." },
+]
+
+const reviewClients = [
+    "Laura Martinez", "Sofia Rodriguez", "Diego Fernandez", "Valentina Gomez",
+    "Facundo Lopez", "Camila Torres", "Matias Sanchez", "Florencia Perez",
+    "Agustin Diaz", "Micaela Ruiz"
+]
+
 const clients = [
-    { firstName: "Laura",     lastName: "Martinez",  age: 25, phoneNumber: 2615551234, email: "laura@test.com",      password: "cliente123", address: "Godoy Cruz, Mendoza",  birthDate: new Date("1999-03-15"), dni: 45123456, userName: "lmartinez" },
-    { firstName: "Sofia",     lastName: "Rodriguez", age: 30, phoneNumber: 2615552345, email: "sofia@test.com",      password: "cliente123", address: "Capital, Mendoza",     birthDate: new Date("1994-07-22"), dni: 38234567, userName: "srodriguez" },
-    { firstName: "Diego",     lastName: "Fernandez", age: 28, phoneNumber: 2615553456, email: "diego@test.com",      password: "cliente123", address: "Maipu, Mendoza",       birthDate: new Date("1996-11-10"), dni: 41345678, userName: "dfernandez" },
-    { firstName: "Valentina", lastName: "Gomez",     age: 22, phoneNumber: 2615554567, email: "valentina@test.com",  password: "cliente123", address: "Lujan, Mendoza",       birthDate: new Date("2002-04-05"), dni: 47456789, userName: "vgomez" },
-    { firstName: "Facundo",   lastName: "Lopez",     age: 33, phoneNumber: 2615555678, email: "facundo@test.com",    password: "cliente123", address: "Las Heras, Mendoza",   birthDate: new Date("1991-09-18"), dni: 36567890, userName: "flopez" },
-    { firstName: "Camila",    lastName: "Torres",    age: 27, phoneNumber: 2615556789, email: "camila@test.com",     password: "cliente123", address: "Guaymallen, Mendoza",  birthDate: new Date("1997-12-30"), dni: 43678901, userName: "ctorres" },
-    { firstName: "Matias",    lastName: "Sanchez",   age: 31, phoneNumber: 2615557890, email: "matias@test.com",     password: "cliente123", address: "San Martin, Mendoza",  birthDate: new Date("1993-06-14"), dni: 37789012, userName: "msanchez" },
-    { firstName: "Florencia", lastName: "Perez",     age: 24, phoneNumber: 2615558901, email: "florencia@test.com",  password: "cliente123", address: "Rivadavia, Mendoza",   birthDate: new Date("2000-02-28"), dni: 46890123, userName: "fperez" },
-    { firstName: "Agustin",   lastName: "Diaz",      age: 29, phoneNumber: 2615559012, email: "agustin@test.com",    password: "cliente123", address: "Junin, Mendoza",       birthDate: new Date("1995-08-03"), dni: 39901234, userName: "adiaz" },
-    { firstName: "Micaela",   lastName: "Ruiz",      age: 26, phoneNumber: 2615550123, email: "micaela@test.com",    password: "cliente123", address: "Tunuyan, Mendoza",     birthDate: new Date("1998-05-17"), dni: 44012345, userName: "mruiz" },
+    { firstName: "Laura",     lastName: "Martinez",  age: 25, phoneNumber: 2615551234, email: "laura@test.com",     password: "cliente123", address: "Godoy Cruz, Mendoza", birthDate: new Date("1999-03-15"), dni: 45123456, userName: "lmartinez" },
+    { firstName: "Sofia",     lastName: "Rodriguez", age: 30, phoneNumber: 2615552345, email: "sofia@test.com",     password: "cliente123", address: "Capital, Mendoza",    birthDate: new Date("1994-07-22"), dni: 38234567, userName: "srodriguez" },
+    { firstName: "Diego",     lastName: "Fernandez", age: 28, phoneNumber: 2615553456, email: "diego@test.com",     password: "cliente123", address: "Maipu, Mendoza",      birthDate: new Date("1996-11-10"), dni: 41345678, userName: "dfernandez" },
+    { firstName: "Valentina", lastName: "Gomez",     age: 22, phoneNumber: 2615554567, email: "valentina@test.com", password: "cliente123", address: "Lujan, Mendoza",      birthDate: new Date("2002-04-05"), dni: 47456789, userName: "vgomez" },
+    { firstName: "Facundo",   lastName: "Lopez",     age: 33, phoneNumber: 2615555678, email: "facundo@test.com",   password: "cliente123", address: "Las Heras, Mendoza",  birthDate: new Date("1991-09-18"), dni: 36567890, userName: "flopez" },
+    { firstName: "Camila",    lastName: "Torres",    age: 27, phoneNumber: 2615556789, email: "camila@test.com",    password: "cliente123", address: "Guaymallen, Mendoza", birthDate: new Date("1997-12-30"), dni: 43678901, userName: "ctorres" },
+    { firstName: "Matias",    lastName: "Sanchez",   age: 31, phoneNumber: 2615557890, email: "matias@test.com",    password: "cliente123", address: "San Martin, Mendoza", birthDate: new Date("1993-06-14"), dni: 37789012, userName: "msanchez" },
+    { firstName: "Florencia", lastName: "Perez",     age: 24, phoneNumber: 2615558901, email: "florencia@test.com", password: "cliente123", address: "Rivadavia, Mendoza",  birthDate: new Date("2000-02-28"), dni: 46890123, userName: "fperez" },
+    { firstName: "Agustin",   lastName: "Diaz",      age: 29, phoneNumber: 2615559012, email: "agustin@test.com",   password: "cliente123", address: "Junin, Mendoza",      birthDate: new Date("1995-08-03"), dni: 39901234, userName: "adiaz" },
+    { firstName: "Micaela",   lastName: "Ruiz",      age: 26, phoneNumber: 2615550123, email: "micaela@test.com",   password: "cliente123", address: "Tunuyan, Mendoza",    birthDate: new Date("1998-05-17"), dni: 44012345, userName: "mruiz" },
 ]
 
 const professionals = [
-    { firstName: "Pedro",     lastName: "Lopez",   age: 35, phoneNumber: 2614789012, email: "pedro@test.com",     password: "prof123", address: "Las Heras, Mendoza",  birthDate: new Date("1990-07-20"), dni: 32567890, userName: "plopez",   specialty: "Plomero",      yearsOfExperience: 10 },
-    { firstName: "Roberto",   lastName: "Silva",   age: 42, phoneNumber: 2614780123, email: "roberto@test.com",   password: "prof123", address: "Maipu, Mendoza",      birthDate: new Date("1983-02-11"), dni: 28678901, userName: "rsilva",   specialty: "Electricista", yearsOfExperience: 18 },
-    { firstName: "Marcelo",   lastName: "Herrera", age: 38, phoneNumber: 2614771234, email: "marcelo@test.com",   password: "prof123", address: "Guaymallen, Mendoza", birthDate: new Date("1987-05-25"), dni: 31789012, userName: "mherrera", specialty: "Carpintero",   yearsOfExperience: 14 },
-    { firstName: "Daniel",    lastName: "Castro",  age: 45, phoneNumber: 2614762345, email: "daniel@test.com",    password: "prof123", address: "Capital, Mendoza",    birthDate: new Date("1980-10-08"), dni: 25890123, userName: "dcastro",  specialty: "Albanil",      yearsOfExperience: 20 },
-    { firstName: "Lucas",     lastName: "Morales", age: 32, phoneNumber: 2614753456, email: "lucas@test.com",     password: "prof123", address: "Rivadavia, Mendoza",  birthDate: new Date("1993-01-17"), dni: 37901234, userName: "lmorales", specialty: "Jardinero",    yearsOfExperience: 8  },
-    { firstName: "Nicolas",   lastName: "Vargas",  age: 40, phoneNumber: 2614744567, email: "nicolas@test.com",   password: "prof123", address: "San Martin, Mendoza", birthDate: new Date("1985-08-30"), dni: 30012345, userName: "nvargas",  specialty: "Gasista",      yearsOfExperience: 16 },
-    { firstName: "Gustavo",   lastName: "Reyes",   age: 36, phoneNumber: 2614735678, email: "gustavo@test.com",   password: "prof123", address: "Junin, Mendoza",      birthDate: new Date("1989-04-12"), dni: 33123456, userName: "greyes",   specialty: "Pintor",       yearsOfExperience: 12 },
-    { firstName: "Adrian",    lastName: "Flores",  age: 44, phoneNumber: 2614726789, email: "adrian@test.com",    password: "prof123", address: "Lujan, Mendoza",      birthDate: new Date("1981-11-03"), dni: 27234567, userName: "aflores",  specialty: "Cerrajero",    yearsOfExperience: 19 },
-    { firstName: "Sergio",    lastName: "Romero",  age: 37, phoneNumber: 2614717890, email: "sergio@test.com",    password: "prof123", address: "Tunuyan, Mendoza",    birthDate: new Date("1988-06-22"), dni: 32345678, userName: "sromero",  specialty: "Soldador",     yearsOfExperience: 13 },
-    { firstName: "Alejandro", lastName: "Mendez",  age: 41, phoneNumber: 2614708901, email: "alejandro@test.com", password: "prof123", address: "Godoy Cruz, Mendoza", birthDate: new Date("1984-09-14"), dni: 29456789, userName: "amendez",  specialty: "Electricista", yearsOfExperience: 17 },
+    // Albanil (10)
+    { firstName: "Daniel",    lastName: "Castro",    age: 45, phoneNumber: 2614100001, email: "dcastro@test.com",    password: "prof123", address: "Capital, Mendoza",    birthDate: new Date("1980-10-08"), dni: 25000001, userName: "dcastro",    specialty: "Albanil", yearsOfExperience: 20, registrationNumber: 10001 },
+    { firstName: "Ricardo",   lastName: "Blanco",    age: 40, phoneNumber: 2614100002, email: "rblanco@test.com",    password: "prof123", address: "Maipu, Mendoza",      birthDate: new Date("1985-03-12"), dni: 25000002, userName: "rblanco",    specialty: "Albanil", yearsOfExperience: 15, registrationNumber: 10002 },
+    { firstName: "Hector",    lastName: "Vega",      age: 50, phoneNumber: 2614100003, email: "hvega@test.com",      password: "prof123", address: "Godoy Cruz, Mendoza", birthDate: new Date("1975-06-20"), dni: 25000003, userName: "hvega",      specialty: "Albanil", yearsOfExperience: 25, registrationNumber: 10003 },
+    { firstName: "Omar",      lastName: "Quintero",  age: 38, phoneNumber: 2614100004, email: "oquintero@test.com",  password: "prof123", address: "Las Heras, Mendoza",  birthDate: new Date("1987-01-05"), dni: 25000004, userName: "oquintero",  specialty: "Albanil", yearsOfExperience: 12, registrationNumber: 10004 },
+    { firstName: "Ramon",     lastName: "Acosta",    age: 43, phoneNumber: 2614100005, email: "racosta@test.com",    password: "prof123", address: "Guaymallen, Mendoza", birthDate: new Date("1982-09-17"), dni: 25000005, userName: "racosta",    specialty: "Albanil", yearsOfExperience: 18, registrationNumber: 10005 },
+    { firstName: "Jorge",     lastName: "Medina",    age: 36, phoneNumber: 2614100006, email: "jmedina@test.com",    password: "prof123", address: "Lujan, Mendoza",      birthDate: new Date("1989-04-30"), dni: 25000006, userName: "jmedina",    specialty: "Albanil", yearsOfExperience: 10, registrationNumber: 10006 },
+    { firstName: "Pablo",     lastName: "Soria",     age: 47, phoneNumber: 2614100007, email: "psoria@test.com",     password: "prof123", address: "San Martin, Mendoza", birthDate: new Date("1978-11-22"), dni: 25000007, userName: "psoria",     specialty: "Albanil", yearsOfExperience: 22, registrationNumber: 10007 },
+    { firstName: "Carlos",    lastName: "Ibarra",    age: 33, phoneNumber: 2614100008, email: "cibarra@test.com",    password: "prof123", address: "Rivadavia, Mendoza",  birthDate: new Date("1992-07-14"), dni: 25000008, userName: "cibarra",    specialty: "Albanil", yearsOfExperience: 8,  registrationNumber: 10008 },
+    { firstName: "Miguel",    lastName: "Paredes",   age: 41, phoneNumber: 2614100009, email: "mparedes@test.com",   password: "prof123", address: "Junin, Mendoza",      birthDate: new Date("1984-02-28"), dni: 25000009, userName: "mparedes",   specialty: "Albanil", yearsOfExperience: 16, registrationNumber: 10009 },
+    { firstName: "Fernando",  lastName: "Salinas",   age: 35, phoneNumber: 2614100010, email: "fsalinas@test.com",   password: "prof123", address: "Tunuyan, Mendoza",    birthDate: new Date("1990-05-10"), dni: 25000010, userName: "fsalinas",   specialty: "Albanil", yearsOfExperience: 9,  registrationNumber: 10010 },
+
+    // Electricista (10)
+    { firstName: "Roberto",   lastName: "Silva",     age: 42, phoneNumber: 2614200001, email: "rsilva@test.com",     password: "prof123", address: "Maipu, Mendoza",      birthDate: new Date("1983-02-11"), dni: 25000011, userName: "rsilva",     specialty: "Electricista", yearsOfExperience: 18, registrationNumber: 20001 },
+    { firstName: "Alejandro", lastName: "Mendez",    age: 41, phoneNumber: 2614200002, email: "amendez@test.com",    password: "prof123", address: "Godoy Cruz, Mendoza", birthDate: new Date("1984-09-14"), dni: 25000012, userName: "amendez",    specialty: "Electricista", yearsOfExperience: 17, registrationNumber: 20002 },
+    { firstName: "Eduardo",   lastName: "Ponce",     age: 38, phoneNumber: 2614200003, email: "eponce@test.com",     password: "prof123", address: "Capital, Mendoza",    birthDate: new Date("1987-12-03"), dni: 25000013, userName: "eponce",     specialty: "Electricista", yearsOfExperience: 13, registrationNumber: 20003 },
+    { firstName: "Leandro",   lastName: "Cabrera",   age: 33, phoneNumber: 2614200004, email: "lcabrera@test.com",   password: "prof123", address: "Las Heras, Mendoza",  birthDate: new Date("1992-08-19"), dni: 25000014, userName: "lcabrera",   specialty: "Electricista", yearsOfExperience: 8,  registrationNumber: 20004 },
+    { firstName: "Maximiliano",lastName: "Rios",     age: 45, phoneNumber: 2614200005, email: "mrios@test.com",      password: "prof123", address: "Guaymallen, Mendoza", birthDate: new Date("1980-03-25"), dni: 25000015, userName: "mrios",      specialty: "Electricista", yearsOfExperience: 20, registrationNumber: 20005 },
+    { firstName: "Sebastian",  lastName: "Gimenez",  age: 36, phoneNumber: 2614200006, email: "sgimenez@test.com",   password: "prof123", address: "Lujan, Mendoza",      birthDate: new Date("1989-07-08"), dni: 25000016, userName: "sgimenez",   specialty: "Electricista", yearsOfExperience: 11, registrationNumber: 20006 },
+    { firstName: "Cristian",  lastName: "Molina",    age: 39, phoneNumber: 2614200007, email: "cmolina@test.com",    password: "prof123", address: "San Martin, Mendoza", birthDate: new Date("1986-01-17"), dni: 25000017, userName: "cmolina",    specialty: "Electricista", yearsOfExperience: 14, registrationNumber: 20007 },
+    { firstName: "Andres",    lastName: "Suarez",    age: 44, phoneNumber: 2614200008, email: "asuarez@test.com",    password: "prof123", address: "Rivadavia, Mendoza",  birthDate: new Date("1981-10-30"), dni: 25000018, userName: "asuarez",    specialty: "Electricista", yearsOfExperience: 19, registrationNumber: 20008 },
+    { firstName: "Gabriel",   lastName: "Peralta",   age: 31, phoneNumber: 2614200009, email: "gperalta@test.com",   password: "prof123", address: "Junin, Mendoza",      birthDate: new Date("1994-04-22"), dni: 25000019, userName: "gperalta",   specialty: "Electricista", yearsOfExperience: 6,  registrationNumber: 20009 },
+    { firstName: "Ivan",      lastName: "Cardenas",  age: 37, phoneNumber: 2614200010, email: "icardenas@test.com",  password: "prof123", address: "Tunuyan, Mendoza",    birthDate: new Date("1988-06-05"), dni: 25000020, userName: "icardenas",  specialty: "Electricista", yearsOfExperience: 12, registrationNumber: 20010 },
+
+    // Plomero (10)
+    { firstName: "Pedro",     lastName: "Lopez",     age: 35, phoneNumber: 2614300001, email: "plopez@test.com",     password: "prof123", address: "Las Heras, Mendoza",  birthDate: new Date("1990-07-20"), dni: 25000021, userName: "plopez",     specialty: "Plomero", yearsOfExperience: 10, registrationNumber: 30001 },
+    { firstName: "Claudio",   lastName: "Navarro",   age: 48, phoneNumber: 2614300002, email: "cnavarro@test.com",   password: "prof123", address: "Maipu, Mendoza",      birthDate: new Date("1977-01-15"), dni: 25000022, userName: "cnavarro",   specialty: "Plomero", yearsOfExperience: 23, registrationNumber: 30002 },
+    { firstName: "Ruben",     lastName: "Escobar",   age: 40, phoneNumber: 2614300003, email: "rescobar@test.com",   password: "prof123", address: "Godoy Cruz, Mendoza", birthDate: new Date("1985-05-28"), dni: 25000023, userName: "rescobar",   specialty: "Plomero", yearsOfExperience: 15, registrationNumber: 30003 },
+    { firstName: "Walter",    lastName: "Benitez",   age: 43, phoneNumber: 2614300004, email: "wbenitez@test.com",   password: "prof123", address: "Capital, Mendoza",    birthDate: new Date("1982-09-09"), dni: 25000024, userName: "wbenitez",   specialty: "Plomero", yearsOfExperience: 18, registrationNumber: 30004 },
+    { firstName: "Hugo",      lastName: "Vera",      age: 37, phoneNumber: 2614300005, email: "hvera@test.com",      password: "prof123", address: "Guaymallen, Mendoza", birthDate: new Date("1988-03-14"), dni: 25000025, userName: "hvera",      specialty: "Plomero", yearsOfExperience: 12, registrationNumber: 30005 },
+    { firstName: "Ezequiel",  lastName: "Campos",    age: 30, phoneNumber: 2614300006, email: "ecampos@test.com",    password: "prof123", address: "Lujan, Mendoza",      birthDate: new Date("1995-11-02"), dni: 25000026, userName: "ecampos",    specialty: "Plomero", yearsOfExperience: 5,  registrationNumber: 30006 },
+    { firstName: "Ariel",     lastName: "Figueroa",  age: 46, phoneNumber: 2614300007, email: "afigueroa@test.com",  password: "prof123", address: "San Martin, Mendoza", birthDate: new Date("1979-07-18"), dni: 25000027, userName: "afigueroa",  specialty: "Plomero", yearsOfExperience: 21, registrationNumber: 30007 },
+    { firstName: "Gonzalo",   lastName: "Rojas",     age: 34, phoneNumber: 2614300008, email: "grojas@test.com",     password: "prof123", address: "Rivadavia, Mendoza",  birthDate: new Date("1991-12-25"), dni: 25000028, userName: "grojas",     specialty: "Plomero", yearsOfExperience: 9,  registrationNumber: 30008 },
+    { firstName: "Leonardo",  lastName: "Aguirre",   age: 39, phoneNumber: 2614300009, email: "laguirre@test.com",   password: "prof123", address: "Junin, Mendoza",      birthDate: new Date("1986-08-07"), dni: 25000029, userName: "laguirre",   specialty: "Plomero", yearsOfExperience: 14, registrationNumber: 30009 },
+    { firstName: "Marcelo",   lastName: "Palacios",  age: 52, phoneNumber: 2614300010, email: "mpalacios@test.com",  password: "prof123", address: "Tunuyan, Mendoza",    birthDate: new Date("1973-04-11"), dni: 25000030, userName: "mpalacios",  specialty: "Plomero", yearsOfExperience: 27, registrationNumber: 30010 },
+
+    // Mecanico (10)
+    { firstName: "Juan",      lastName: "Ferreyra",  age: 38, phoneNumber: 2614400001, email: "jferreyra@test.com",  password: "prof123", address: "Capital, Mendoza",    birthDate: new Date("1987-02-14"), dni: 25000031, userName: "jferreyra",  specialty: "Mecanico", yearsOfExperience: 13, registrationNumber: 40001 },
+    { firstName: "Rodrigo",   lastName: "Godoy",     age: 35, phoneNumber: 2614400002, email: "rgodoy@test.com",     password: "prof123", address: "Maipu, Mendoza",      birthDate: new Date("1990-06-30"), dni: 25000032, userName: "rgodoy",     specialty: "Mecanico", yearsOfExperience: 10, registrationNumber: 40002 },
+    { firstName: "Diego",     lastName: "Alvarez",   age: 44, phoneNumber: 2614400003, email: "dalvarez@test.com",   password: "prof123", address: "Godoy Cruz, Mendoza", birthDate: new Date("1981-10-16"), dni: 25000033, userName: "dalvarez",   specialty: "Mecanico", yearsOfExperience: 19, registrationNumber: 40003 },
+    { firstName: "Emiliano",  lastName: "Ortiz",     age: 32, phoneNumber: 2614400004, email: "eortiz@test.com",     password: "prof123", address: "Las Heras, Mendoza",  birthDate: new Date("1993-03-08"), dni: 25000034, userName: "eortiz",     specialty: "Mecanico", yearsOfExperience: 7,  registrationNumber: 40004 },
+    { firstName: "Hernan",    lastName: "Contreras", age: 47, phoneNumber: 2614400005, email: "hcontreras@test.com", password: "prof123", address: "Guaymallen, Mendoza", birthDate: new Date("1978-08-23"), dni: 25000035, userName: "hcontreras", specialty: "Mecanico", yearsOfExperience: 22, registrationNumber: 40005 },
+    { firstName: "Damian",    lastName: "Juarez",    age: 36, phoneNumber: 2614400006, email: "djuarez@test.com",    password: "prof123", address: "Lujan, Mendoza",      birthDate: new Date("1989-12-01"), dni: 25000036, userName: "djuarez",    specialty: "Mecanico", yearsOfExperience: 11, registrationNumber: 40006 },
+    { firstName: "Federico",  lastName: "Luna",      age: 41, phoneNumber: 2614400007, email: "fluna@test.com",      password: "prof123", address: "San Martin, Mendoza", birthDate: new Date("1984-05-19"), dni: 25000037, userName: "fluna",      specialty: "Mecanico", yearsOfExperience: 16, registrationNumber: 40007 },
+    { firstName: "Mauricio",  lastName: "Carrizo",   age: 39, phoneNumber: 2614400008, email: "mcarrizo@test.com",   password: "prof123", address: "Rivadavia, Mendoza",  birthDate: new Date("1986-09-27"), dni: 25000038, userName: "mcarrizo",   specialty: "Mecanico", yearsOfExperience: 14, registrationNumber: 40008 },
+    { firstName: "Nicolas",   lastName: "Quiroga",   age: 33, phoneNumber: 2614400009, email: "nquiroga@test.com",   password: "prof123", address: "Junin, Mendoza",      birthDate: new Date("1992-01-13"), dni: 25000039, userName: "nquiroga",   specialty: "Mecanico", yearsOfExperience: 8,  registrationNumber: 40009 },
+    { firstName: "Santiago",  lastName: "Paz",       age: 49, phoneNumber: 2614400010, email: "spaz@test.com",       password: "prof123", address: "Tunuyan, Mendoza",    birthDate: new Date("1976-07-04"), dni: 25000040, userName: "spaz",       specialty: "Mecanico", yearsOfExperience: 24, registrationNumber: 40010 },
+
+    // Cerrajero (10)
+    { firstName: "Adrian",    lastName: "Flores",    age: 44, phoneNumber: 2614500001, email: "aflores@test.com",    password: "prof123", address: "Lujan, Mendoza",      birthDate: new Date("1981-11-03"), dni: 25000041, userName: "aflores",    specialty: "Cerrajero", yearsOfExperience: 19, registrationNumber: 50001 },
+    { firstName: "Cesar",     lastName: "Miranda",   age: 37, phoneNumber: 2614500002, email: "cmiranda@test.com",   password: "prof123", address: "Capital, Mendoza",    birthDate: new Date("1988-04-20"), dni: 25000042, userName: "cmiranda",   specialty: "Cerrajero", yearsOfExperience: 12, registrationNumber: 50002 },
+    { firstName: "Esteban",   lastName: "Leal",      age: 42, phoneNumber: 2614500003, email: "eleal@test.com",      password: "prof123", address: "Maipu, Mendoza",      birthDate: new Date("1983-08-15"), dni: 25000043, userName: "eleal",      specialty: "Cerrajero", yearsOfExperience: 17, registrationNumber: 50003 },
+    { firstName: "Fabian",    lastName: "Montes",    age: 35, phoneNumber: 2614500004, email: "fmontes@test.com",    password: "prof123", address: "Godoy Cruz, Mendoza", birthDate: new Date("1990-02-06"), dni: 25000044, userName: "fmontes",    specialty: "Cerrajero", yearsOfExperience: 10, registrationNumber: 50004 },
+    { firstName: "Ignacio",   lastName: "Soto",      age: 29, phoneNumber: 2614500005, email: "isoto@test.com",      password: "prof123", address: "Las Heras, Mendoza",  birthDate: new Date("1996-10-18"), dni: 25000045, userName: "isoto",      specialty: "Cerrajero", yearsOfExperience: 4,  registrationNumber: 50005 },
+    { firstName: "Julian",    lastName: "Barrios",   age: 46, phoneNumber: 2614500006, email: "jbarrios@test.com",   password: "prof123", address: "Guaymallen, Mendoza", birthDate: new Date("1979-06-24"), dni: 25000046, userName: "jbarrios",   specialty: "Cerrajero", yearsOfExperience: 21, registrationNumber: 50006 },
+    { firstName: "Kevin",     lastName: "Villareal", age: 28, phoneNumber: 2614500007, email: "kvillareal@test.com", password: "prof123", address: "San Martin, Mendoza", birthDate: new Date("1997-01-31"), dni: 25000047, userName: "kvillareal", specialty: "Cerrajero", yearsOfExperience: 3,  registrationNumber: 50007 },
+    { firstName: "Lorenzo",   lastName: "Mena",      age: 53, phoneNumber: 2614500008, email: "lmena@test.com",      password: "prof123", address: "Rivadavia, Mendoza",  birthDate: new Date("1972-09-09"), dni: 25000048, userName: "lmena",      specialty: "Cerrajero", yearsOfExperience: 28, registrationNumber: 50008 },
+    { firstName: "Marcos",    lastName: "Trujillo",  age: 40, phoneNumber: 2614500009, email: "mtrujillo@test.com",  password: "prof123", address: "Junin, Mendoza",      birthDate: new Date("1985-03-22"), dni: 25000049, userName: "mtrujillo",  specialty: "Cerrajero", yearsOfExperience: 15, registrationNumber: 50009 },
+    { firstName: "Nahuel",    lastName: "Arce",      age: 31, phoneNumber: 2614500010, email: "narce@test.com",      password: "prof123", address: "Tunuyan, Mendoza",    birthDate: new Date("1994-11-14"), dni: 25000050, userName: "narce",      specialty: "Cerrajero", yearsOfExperience: 6,  registrationNumber: 50010 },
+
+    // Metalurgico (10)
+    { firstName: "Sergio",    lastName: "Romero",    age: 37, phoneNumber: 2614600001, email: "sromero@test.com",    password: "prof123", address: "Tunuyan, Mendoza",    birthDate: new Date("1988-06-22"), dni: 25000051, userName: "sromero",    specialty: "Metalurgico", yearsOfExperience: 13, registrationNumber: 60001 },
+    { firstName: "Oscar",     lastName: "Villanueva",age: 50, phoneNumber: 2614600002, email: "ovillanueva@test.com",password: "prof123", address: "Capital, Mendoza",    birthDate: new Date("1975-01-07"), dni: 25000052, userName: "ovillanueva",specialty: "Metalurgico", yearsOfExperience: 25, registrationNumber: 60002 },
+    { firstName: "Patricio",  lastName: "Delgado",   age: 43, phoneNumber: 2614600003, email: "pdelgado@test.com",   password: "prof123", address: "Maipu, Mendoza",      birthDate: new Date("1982-07-29"), dni: 25000053, userName: "pdelgado",   specialty: "Metalurgico", yearsOfExperience: 18, registrationNumber: 60003 },
+    { firstName: "Raul",      lastName: "Sepulveda", age: 46, phoneNumber: 2614600004, email: "rsepulveda@test.com", password: "prof123", address: "Godoy Cruz, Mendoza", birthDate: new Date("1979-04-13"), dni: 25000054, userName: "rsepulveda", specialty: "Metalurgico", yearsOfExperience: 21, registrationNumber: 60004 },
+    { firstName: "Tomas",     lastName: "Bravo",     age: 34, phoneNumber: 2614600005, email: "tbravo@test.com",     password: "prof123", address: "Las Heras, Mendoza",  birthDate: new Date("1991-10-05"), dni: 25000055, userName: "tbravo",     specialty: "Metalurgico", yearsOfExperience: 9,  registrationNumber: 60005 },
+    { firstName: "Victor",    lastName: "Parra",     age: 41, phoneNumber: 2614600006, email: "vparra@test.com",     password: "prof123", address: "Guaymallen, Mendoza", birthDate: new Date("1984-02-17"), dni: 25000056, userName: "vparra",     specialty: "Metalurgico", yearsOfExperience: 16, registrationNumber: 60006 },
+    { firstName: "Wilson",    lastName: "Tapia",     age: 38, phoneNumber: 2614600007, email: "wtapia@test.com",     password: "prof123", address: "Lujan, Mendoza",      birthDate: new Date("1987-08-28"), dni: 25000057, userName: "wtapia",     specialty: "Metalurgico", yearsOfExperience: 13, registrationNumber: 60007 },
+    { firstName: "Alfredo",   lastName: "Cortes",    age: 55, phoneNumber: 2614600008, email: "acortes@test.com",    password: "prof123", address: "San Martin, Mendoza", birthDate: new Date("1970-05-03"), dni: 25000058, userName: "acortes",    specialty: "Metalurgico", yearsOfExperience: 30, registrationNumber: 60008 },
+    { firstName: "Bernardo",  lastName: "Lara",      age: 32, phoneNumber: 2614600009, email: "blara@test.com",      password: "prof123", address: "Rivadavia, Mendoza",  birthDate: new Date("1993-12-19"), dni: 25000059, userName: "blara",      specialty: "Metalurgico", yearsOfExperience: 7,  registrationNumber: 60009 },
+    { firstName: "Claudio",   lastName: "Espinoza",  age: 44, phoneNumber: 2614600010, email: "cespinoza@test.com",  password: "prof123", address: "Junin, Mendoza",      birthDate: new Date("1981-03-26"), dni: 25000060, userName: "cespinoza",  specialty: "Metalurgico", yearsOfExperience: 19, registrationNumber: 60010 },
+
+    // Gasista (10)
+    { firstName: "Nicolas",   lastName: "Vargas",    age: 40, phoneNumber: 2614700001, email: "nvargas@test.com",    password: "prof123", address: "San Martin, Mendoza", birthDate: new Date("1985-08-30"), dni: 25000061, userName: "nvargas",    specialty: "Gasista", yearsOfExperience: 16, registrationNumber: 70001 },
+    { firstName: "Dario",     lastName: "Heredia",   age: 36, phoneNumber: 2614700002, email: "dheredia@test.com",   password: "prof123", address: "Capital, Mendoza",    birthDate: new Date("1989-02-10"), dni: 25000062, userName: "dheredia",   specialty: "Gasista", yearsOfExperience: 11, registrationNumber: 70002 },
+    { firstName: "Enrique",   lastName: "Maldonado", age: 49, phoneNumber: 2614700003, email: "emaldonado@test.com", password: "prof123", address: "Maipu, Mendoza",      birthDate: new Date("1976-06-17"), dni: 25000063, userName: "emaldonado", specialty: "Gasista", yearsOfExperience: 24, registrationNumber: 70003 },
+    { firstName: "Flavio",    lastName: "Arias",     age: 33, phoneNumber: 2614700004, email: "farias@test.com",     password: "prof123", address: "Godoy Cruz, Mendoza", birthDate: new Date("1992-10-29"), dni: 25000064, userName: "farias",     specialty: "Gasista", yearsOfExperience: 8,  registrationNumber: 70004 },
+    { firstName: "Gaston",    lastName: "Coria",     age: 42, phoneNumber: 2614700005, email: "gcoria@test.com",     password: "prof123", address: "Las Heras, Mendoza",  birthDate: new Date("1983-04-08"), dni: 25000065, userName: "gcoria",     specialty: "Gasista", yearsOfExperience: 17, registrationNumber: 70005 },
+    { firstName: "Horacio",   lastName: "Peña",      age: 47, phoneNumber: 2614700006, email: "hpena@test.com",      password: "prof123", address: "Guaymallen, Mendoza", birthDate: new Date("1978-09-21"), dni: 25000066, userName: "hpena",      specialty: "Gasista", yearsOfExperience: 22, registrationNumber: 70006 },
+    { firstName: "Israel",    lastName: "Cisneros",  age: 31, phoneNumber: 2614700007, email: "icisneros@test.com",  password: "prof123", address: "Lujan, Mendoza",      birthDate: new Date("1994-01-16"), dni: 25000067, userName: "icisneros",  specialty: "Gasista", yearsOfExperience: 6,  registrationNumber: 70007 },
+    { firstName: "Javier",    lastName: "Bustos",    age: 45, phoneNumber: 2614700008, email: "jbustos@test.com",    password: "prof123", address: "Rivadavia, Mendoza",  birthDate: new Date("1980-07-03"), dni: 25000068, userName: "jbustos",    specialty: "Gasista", yearsOfExperience: 20, registrationNumber: 70008 },
+    { firstName: "Kenneth",   lastName: "Pacheco",   age: 38, phoneNumber: 2614700009, email: "kpacheco@test.com",   password: "prof123", address: "Junin, Mendoza",      birthDate: new Date("1987-11-27"), dni: 25000069, userName: "kpacheco",   specialty: "Gasista", yearsOfExperience: 13, registrationNumber: 70009 },
+    { firstName: "Luis",      lastName: "Valenzuela",age: 52, phoneNumber: 2614700010, email: "lvalenzuela@test.com",password: "prof123", address: "Tunuyan, Mendoza",    birthDate: new Date("1973-03-12"), dni: 25000070, userName: "lvalenzuela",specialty: "Gasista", yearsOfExperience: 27, registrationNumber: 70010 },
 ]
 
 async function seed() {
     await AppDataSource.initialize()
     const userRepository = AppDataSource.getRepository(User)
+    const reviewRepository = AppDataSource.getRepository(Review)
 
     console.log("Limpiando datos de prueba anteriores...")
+    await reviewRepository.query('DELETE FROM review')
     await userRepository.delete({ role: Role.CLIENT })
     await userRepository.delete({ role: Role.PROFESSIONAL })
 
     console.log("Creando 10 clientes...")
     for (const data of clients) {
-        const existing = await userRepository.findOne({ where: { dni: data.dni } })
-        if (!existing) {
-            await userRepository.save(userRepository.create({ ...data, role: Role.CLIENT }))
-            console.log(`  ✓ ${data.firstName} ${data.lastName}`)
-        } else {
-            console.log(`  - ${data.firstName} ${data.lastName} ya existe, omitiendo`)
+        await userRepository.save(userRepository.create({ ...data, role: Role.CLIENT }))
+        console.log(`  ✓ ${data.firstName} ${data.lastName}`)
+    }
+
+    const specialties = ["Albanil", "Electricista", "Plomero", "Mecanico", "Cerrajero", "Metalurgico", "Gasista"]
+    console.log(`\nCreando 70 profesionales (10 por cada especialidad)...`)
+    const savedProfessionals: User[] = []
+    for (const specialty of specialties) {
+        const group = professionals.filter(p => p.specialty === specialty)
+        console.log(`\n  [${specialty}]`)
+        for (const data of group) {
+            const pro = await userRepository.save(userRepository.create({ ...data, role: Role.PROFESSIONAL }))
+            savedProfessionals.push(pro)
+            console.log(`    ✓ ${data.firstName} ${data.lastName}`)
         }
     }
 
-    console.log("Creando 10 profesionales...")
-    for (const data of professionals) {
-        const existing = await userRepository.findOne({ where: { dni: data.dni } })
-        if (!existing) {
-            await userRepository.save(userRepository.create({ ...data, role: Role.PROFESSIONAL }))
-            console.log(`  ✓ ${data.firstName} ${data.lastName} (${data.specialty})`)
-        } else {
-            console.log(`  - ${data.firstName} ${data.lastName} ya existe, omitiendo`)
+    console.log("\nCreando reseñas de prueba...")
+    for (const pro of savedProfessionals) {
+        const numReviews = Math.floor(Math.random() * 3) + 3 // 3 a 5 reseñas por profesional
+        for (let i = 0; i < numReviews; i++) {
+            const review = reviewComments[Math.floor(Math.random() * reviewComments.length)]
+            const client = reviewClients[Math.floor(Math.random() * reviewClients.length)]
+            await reviewRepository.save(reviewRepository.create({
+                professionalId: pro.id,
+                clientName: client,
+                rating: review.rating,
+                comment: review.comment
+            }))
         }
     }
+    console.log("  ✓ Reseñas creadas para todos los profesionales")
 
-    console.log("\nSeed completado.")
+    console.log("\nSeed completado: 10 clientes + 70 profesionales + reseñas.")
     await AppDataSource.destroy()
 }
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,10 +5,12 @@
   "dependencies": {
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/user-event": "^13.5.0",
+    "leaflet": "^1.9.4",
     "postcss": "^8.4.31",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.11.0",
+    "react-leaflet": "^4.2.1",
     "react-modal": "^3.16.1",
     "react-router-dom": "^6.18.0",
     "react-scripts": "^5.0.1",
@@ -42,6 +44,7 @@
   },
   "devDependencies": {
     "@testing-library/react": "^14.0.0",
+    "@types/leaflet": "^1.9.21",
     "jest": "^27.5.1"
   }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,11 +1,12 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { Home } from "./components/Home/Home";
-import {LoginForm} from "./components/LoginForm/LoginForm"; 
-import {SignUpForm} from "./components/SignUpForm/SignUpForm"
+import { LoginForm } from "./components/LoginForm/LoginForm";
+import { SignUpForm } from "./components/SignUpForm/SignUpForm";
 import { SearchResults } from "./components/SearchResults/SearchResults";
 import { ProfileForm } from "./components/ProfileForm/ProfileForm";
-export default function App() {
+import { ProfessionalProfile } from "./components/ProfessionalProfile/ProfessionalProfile";
 
+export default function App() {
   return (
     <div>
       <BrowserRouter>
@@ -15,7 +16,7 @@ export default function App() {
           <Route path="/profile-settings" element={<ProfileForm/>}/>
           <Route path="/" element={<Home/>}/>
           <Route path="/searchResults" element={<SearchResults/>}/>
-
+          <Route path="/professional/:id" element={<ProfessionalProfile/>}/>
         </Routes>
       </BrowserRouter>
     </div>

--- a/frontend/src/components/Hero/Hero.jsx
+++ b/frontend/src/components/Hero/Hero.jsx
@@ -1,6 +1,18 @@
-import React from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
+import { useNavigate } from "react-router-dom";
+
 export const Hero = () => {
+  const [query, setQuery] = useState('');
+  const navigate = useNavigate();
+
+  const handleSearch = (e) => {
+    e.preventDefault();
+    if (query.trim()) {
+      navigate(`/searchResults?q=${encodeURIComponent(query.trim())}`);
+    }
+  };
+
   return (
     <Section id="hero">
       <div className="background">
@@ -15,23 +27,19 @@ export const Hero = () => {
             tenetur!
           </p>
         </div>
-        <div className="search">
+        <form className="search" onSubmit={handleSearch}>
           <div className="container">
-            <label htmlFor=""></label>
-            <input type="text" placeholder="Ingresa tu busqueda" />
+            <label htmlFor="search"></label>
+            <input
+              id="search"
+              type="text"
+              placeholder="Ingresa tu busqueda"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+            />
           </div>
-          {/* <div className="container">
-            <label htmlFor="">Check-in</label>
-            <input type="date" />
-          </div> */}
-          <div className="container">
-            <label htmlFor="   "></label>
-            <input type="text" placeholder="Ubicacion" />
-          </div>
-          <a href="/searchResults">
-          <button>Buscar</button>
-          </a>
-        </div>
+          <button type="submit">Buscar</button>
+        </form>
       </div>
     </Section>
   );

--- a/frontend/src/components/Hero/Hero.jsx
+++ b/frontend/src/components/Hero/Hero.jsx
@@ -22,9 +22,8 @@ export const Hero = () => {
         <div className="title">
           <h1>Encontrá la Mejor solución de forma fácil</h1>
           <p>
-            Lorem ipsum dolor sit amet consectetur adipisicing elit. Facere
-            natus, enim ipsam magnam odit deserunt itaque? Minima earum velit
-            tenetur!
+            Conectamos clientes con profesionales de confianza. Plomeros,
+            electricistas, albañiles y más, cerca tuyo y listos para ayudarte.
           </p>
         </div>
         <form className="search" onSubmit={handleSearch}>
@@ -94,6 +93,7 @@ const Section = styled.section`
         justify-content: center;
         flex-direction: column;
         padding: 0 1.5rem;
+        min-width: 220px;
         label {
           font-size: 1.1rem;
           color: #03045e;
@@ -103,6 +103,7 @@ const Section = styled.section`
           border: none;
           text-align: center;
           color: black;
+          width: 250px;
           &[type="date"] {
             padding-left: 3rem;
           }

--- a/frontend/src/components/LoginForm/LoginForm.jsx
+++ b/frontend/src/components/LoginForm/LoginForm.jsx
@@ -19,6 +19,12 @@ const Card = styled.div`
   max-width: 420px;
 `;
 
+const Logo = styled.img`
+  display: block;
+  margin: 0 auto 1.5rem;
+  width: 160px;
+`;
+
 const Title = styled.h2`
   color: #0E2E50;
   text-align: center;
@@ -157,6 +163,7 @@ export const LoginForm = () => {
   return (
     <Wrapper>
       <Card>
+        <Logo src="/img/tuoficio_logo.png" alt="Tu Oficio" />
         <Title>Iniciar sesión</Title>
 
         {error && <ErrorMessage>{error}</ErrorMessage>}

--- a/frontend/src/components/LoginForm/LoginForm.jsx
+++ b/frontend/src/components/LoginForm/LoginForm.jsx
@@ -1,96 +1,211 @@
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #f5f5f5;
+`;
+
+const Card = styled.div`
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 4px 24px rgba(0,0,0,0.1);
+  padding: 2.5rem;
+  width: 100%;
+  max-width: 420px;
+`;
+
+const Title = styled.h2`
+  color: #0E2E50;
+  text-align: center;
+  margin-bottom: 2rem;
+  font-size: 1.8rem;
+`;
+
+const FormGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1.2rem;
+`;
+
+const Label = styled.label`
+  color: #0E2E50;
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+  font-size: 0.9rem;
+`;
+
+const Input = styled.input`
+  padding: 0.75rem 1rem;
+  border: 1.5px solid #ccc;
+  border-radius: 8px;
+  font-size: 1rem;
+  transition: border-color 0.2s;
+
+  &:focus {
+    outline: none;
+    border-color: #FF6922;
+  }
+`;
+
+const Select = styled.select`
+  padding: 0.75rem 1rem;
+  border: 1.5px solid #ccc;
+  border-radius: 8px;
+  font-size: 1rem;
+  background: #fff;
+  cursor: pointer;
+
+  &:focus {
+    outline: none;
+    border-color: #FF6922;
+  }
+`;
+
+const SubmitButton = styled.button`
+  width: 100%;
+  background-color: #FF6922;
+  color: #fff;
+  padding: 0.85rem;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  margin-top: 0.5rem;
+  transition: background-color 0.2s;
+
+  &:hover {
+    background-color: #e55a10;
+  }
+
+  &:disabled {
+    background-color: #ccc;
+    cursor: not-allowed;
+  }
+`;
+
+const SecondaryButton = styled(Link)`
+  display: block;
+  text-align: center;
+  margin-top: 0.8rem;
+  padding: 0.75rem;
+  border: 1.5px solid #0E2E50;
+  border-radius: 8px;
+  color: #0E2E50;
+  font-weight: 600;
+  text-decoration: none;
+  transition: all 0.2s;
+
+  &:hover {
+    background-color: #0E2E50;
+    color: #fff;
+  }
+`;
+
+const ErrorMessage = styled.p`
+  color: #e53935;
+  background: #fdecea;
+  border-radius: 6px;
+  padding: 0.6rem 1rem;
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+  text-align: center;
+`;
 
 export const LoginForm = () => {
+  const navigate = useNavigate();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [userType, setUserType] = useState('cliente');
-  const [loggedIn, setLoggedIn] = useState(false);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-
-    const loginData = {
-      email: email,
-      password: password,
-      userType: userType
-    };
+    setError('');
+    setLoading(true);
 
     try {
-      let response;
-      if (userType === 'cliente') {
-        response = await fetch('http://localhost:3000/login-client', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(loginData),
-        });
-      } else if (userType === 'profesional') {
-        response = await fetch('http://localhost:3000/login-professional', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(loginData),
-        });
-      }
-      const data = await response.json();
-      console.log(data)
-      if (response.ok) {
-        window.alert(data.message);
-        window.location.href = "/";
-        setLoggedIn(true)
-      } else {
-        window.alert(data.message);
-      }
+      const endpoint = userType === 'cliente' ? '/login-client' : '/login-professional';
+      const response = await fetch(`http://localhost:3000${endpoint}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
 
-    } catch (error) {
-      console.error('Error al iniciar sesión:', error);
+      const data = await response.json();
+
+      if (response.ok) {
+        localStorage.setItem('token', data.token);
+        localStorage.setItem('user', JSON.stringify(data.client || data.professional));
+        navigate('/');
+      } else {
+        setError(data.message);
+      }
+    } catch (err) {
+      setError('Error de conexión. Intente nuevamente.');
+    } finally {
+      setLoading(false);
     }
   };
 
-  if (loggedIn) {
-    return <Link to="/" />;
-  }
-
   return (
-    <div>
-      <h2>Iniciar sesión</h2>
-      <form onSubmit={handleSubmit}>
-        <div>
-          <label htmlFor="email">Correo Electrónico</label>
-          <input
-            type="email"
-            id="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-          />
-        </div>
-        <div>
-          <label htmlFor="password">Contraseña</label>
-          <input
-            type="password"
-            id="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-          />
-        </div>
-        <div>
-          <label htmlFor="userType">Tipo de Usuario:</label>
-          <select
-            id="userType"
-            value={userType}
-            onChange={(e) => setUserType(e.target.value)}
-          >
-            <option value="cliente">Cliente</option>
-            <option value="profesional">Profesional</option>
-          </select>
-        </div>
-        <button type="submit">Iniciar Sesión</button>
-        <Link to="/signup"><button type="submit">Registrarse</button></Link>
-        <Link to="/"><button type="submit">Volver</button></Link>
-      </form>
-    </div>
+    <Wrapper>
+      <Card>
+        <Title>Iniciar sesión</Title>
+
+        {error && <ErrorMessage>{error}</ErrorMessage>}
+
+        <form onSubmit={handleSubmit}>
+          <FormGroup>
+            <Label htmlFor="userType">Tipo de usuario</Label>
+            <Select
+              id="userType"
+              value={userType}
+              onChange={(e) => setUserType(e.target.value)}
+            >
+              <option value="cliente">Cliente</option>
+              <option value="profesional">Profesional</option>
+            </Select>
+          </FormGroup>
+
+          <FormGroup>
+            <Label htmlFor="email">Correo electrónico</Label>
+            <Input
+              type="email"
+              id="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="tu@email.com"
+              required
+            />
+          </FormGroup>
+
+          <FormGroup>
+            <Label htmlFor="password">Contraseña</Label>
+            <Input
+              type="password"
+              id="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="••••••••"
+              required
+            />
+          </FormGroup>
+
+          <SubmitButton type="submit" disabled={loading}>
+            {loading ? 'Ingresando...' : 'Iniciar sesión'}
+          </SubmitButton>
+
+          <SecondaryButton to="/signup">Crear cuenta</SecondaryButton>
+          <SecondaryButton to="/">Volver al inicio</SecondaryButton>
+        </form>
+      </Card>
+    </Wrapper>
   );
-}
+};

--- a/frontend/src/components/Navbar/Navbar.jsx
+++ b/frontend/src/components/Navbar/Navbar.jsx
@@ -2,19 +2,29 @@ import React, { useState } from "react";
 import styled from "styled-components";
 import { GiHamburgerMenu } from "react-icons/gi";
 import { VscChromeClose } from "react-icons/vsc";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 export const Navbar = () => {
   const [navbarState, setNavbarState] = useState(false);
+  const navigate = useNavigate();
+
+  const storedUser = localStorage.getItem("user");
+  const user = storedUser ? JSON.parse(storedUser) : null;
+
+  const handleLogout = () => {
+    localStorage.removeItem("token");
+    localStorage.removeItem("user");
+    navigate("/");
+  };
+
   return (
     <>
       <Nav>
         <div className="brand">
           <div className="container">
             <a href="/#">
-              <img src={"../img/tuoficio_logo.png"} alt="" style={{ width: '500px', height: 'auto' }}/>
+              <img src={"/img/tuoficio_logo.png"} alt="Tu Oficio" style={{ width: '200px', height: 'auto' }}/>
             </a>
-            
           </div>
           <div className="toggle">
             {navbarState ? (
@@ -26,57 +36,49 @@ export const Navbar = () => {
         </div>
 
         <ul>
-          <li>
-            <a href="/#">Home</a>
-          </li>
-          <li>
-            <a href="/#categories">Categorias</a>
-          </li>
-          <li>
-            <a href="/#recommend">Explorar</a>
-          </li>
-          <li>
-            <a href="/#testimonials">Reseñas</a>
-          </li>
-          <li>
-            <Link to="/profile-settings"><a>Mi Perfil</a></Link>
-          </li>
+          <li><a href="/#">Home</a></li>
+          <li><a href="/#categories">Categorias</a></li>
+          <li><a href="/#recommend">Explorar</a></li>
+          <li><a href="/#testimonials">Reseñas</a></li>
+          {user && <li><Link to="/profile-settings">Mi Perfil</Link></li>}
         </ul>
-        <Link to="/login" ><button>Iniciar Sesion</button></Link>
+
+        {user ? (
+          <UserMenu>
+            <UserInfo>
+              <UserAvatar>{user.firstName?.charAt(0).toUpperCase()}</UserAvatar>
+              <UserName>{user.firstName} {user.lastName}</UserName>
+              <UserRole>{user.role}</UserRole>
+            </UserInfo>
+            <LogoutButton onClick={handleLogout}>Cerrar sesión</LogoutButton>
+          </UserMenu>
+        ) : (
+          <Link to="/login"><button>Iniciar Sesión</button></Link>
+        )}
       </Nav>
+
       <ResponsiveNav state={navbarState}>
-        
         <ul>
-          <li>
-            <a href="#home" onClick={() => setNavbarState(false)}>
-              Home
-            </a>
-          </li>
-          <li>
-            <a href="#categories" onClick={() => setNavbarState(false)}>
-              Categorias
-            </a>
-          </li>
-          <li>
-            <a href="#recommend" onClick={() => setNavbarState(false)}>
-              Explorar
-            </a>
-          </li>
-          <li>
-            <a href="#testimonials" onClick={() => setNavbarState(false)}>
-              Acceder
-            </a>
-          </li>
+          <li><a href="#home" onClick={() => setNavbarState(false)}>Home</a></li>
+          <li><a href="#categories" onClick={() => setNavbarState(false)}>Categorias</a></li>
+          <li><a href="#recommend" onClick={() => setNavbarState(false)}>Explorar</a></li>
+          <li><a href="#testimonials" onClick={() => setNavbarState(false)}>Reseñas</a></li>
+          {user ? (
+            <li><a href="#" onClick={handleLogout}>Cerrar sesión</a></li>
+          ) : (
+            <li><Link to="/login" onClick={() => setNavbarState(false)}>Iniciar Sesión</Link></li>
+          )}
         </ul>
       </ResponsiveNav>
     </>
   );
-}
+};
 
 const Nav = styled.nav`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  padding: 0 1rem;
   .brand {
     .container {
       cursor: pointer;
@@ -84,9 +86,6 @@ const Nav = styled.nav`
       justify-content: center;
       align-items: center;
       gap: 0.4rem;
-      font-size: 1.2rem;
-      font-weight: 900;
-      text-transform: uppercase;
     }
     .toggle {
       display: none;
@@ -102,15 +101,11 @@ const Nav = styled.nav`
         color: #FF6922;
         font-size: 1.2rem;
         transition: 0.1s ease-in-out;
-        &:hover {
-          color: #0E2E50;
-        }
+        &:hover { color: #0E2E50; }
       }
-      &:first-of-type {
-        a {
-          color: #023e8a;
-          font-weight: 900;
-        }
+      &:first-of-type a {
+        color: #023e8a;
+        font-weight: 900;
       }
     }
   }
@@ -125,9 +120,7 @@ const Nav = styled.nav`
     letter-spacing: 0.1rem;
     text-transform: uppercase;
     transition: 0.3s ease-in-out;
-    &:hover {
-      background-color: #023e8a;
-    }
+    &:hover { background-color: #023e8a; }
   }
   @media screen and (min-width: 280px) and (max-width: 1080px) {
     .brand {
@@ -135,16 +128,66 @@ const Nav = styled.nav`
       justify-content: space-between;
       align-items: center;
       width: 100%;
-      .toggle {
-        display: block;
-      }
+      .toggle { display: block; }
     }
-    ul {
-      display: none;
-    }
-    button {
-      display: none;
-    }
+    ul { display: none; }
+    button { display: none; }
+  }
+`;
+
+const UserMenu = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+`;
+
+const UserInfo = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+`;
+
+const UserAvatar = styled.div`
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  background-color: #FF6922;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 1rem;
+`;
+
+const UserName = styled.span`
+  font-weight: 600;
+  color: #0E2E50;
+  font-size: 0.95rem;
+`;
+
+const UserRole = styled.span`
+  font-size: 0.75rem;
+  color: #fff;
+  background-color: #48cae4;
+  padding: 0.15rem 0.5rem;
+  border-radius: 10px;
+  text-transform: capitalize;
+`;
+
+const LogoutButton = styled.button`
+  padding: 0.4rem 0.9rem !important;
+  background-color: transparent !important;
+  color: #e53935 !important;
+  border: 1.5px solid #e53935 !important;
+  border-radius: 1rem !important;
+  font-size: 0.85rem !important;
+  letter-spacing: 0 !important;
+  cursor: pointer;
+  transition: 0.2s;
+  &:hover {
+    background-color: #e53935 !important;
+    color: #fff !important;
   }
 `;
 
@@ -165,21 +208,16 @@ const ResponsiveNav = styled.div`
       width: 100%;
       margin: 1rem 0;
       margin-left: 2rem;
-
       a {
         text-decoration: none;
         color: #0077b6;
         font-size: 1.2rem;
         transition: 0.1s ease-in-out;
-        &:hover {
-          color: #023e8a;
-        }
+        &:hover { color: #023e8a; }
       }
-      &:first-of-type {
-        a {
-          color: #023e8a;
-          font-weight: 900;
-        }
+      &:first-of-type a {
+        color: #023e8a;
+        font-weight: 900;
       }
     }
   }

--- a/frontend/src/components/ProfessionalProfile/ProfessionalProfile.jsx
+++ b/frontend/src/components/ProfessionalProfile/ProfessionalProfile.jsx
@@ -1,0 +1,380 @@
+import React, { useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import styled from "styled-components";
+import { Navbar } from "../Navbar/Navbar";
+import { Footer } from "../Footer/Footer";
+
+const specialtyImages = {
+  Plomero: "/img/plomero.jpeg",
+  Electricista: "/img/electricista.jpeg",
+  Carpintero: "/img/oficio1.png",
+  Albanil: "/img/albanil.jpeg",
+  Jardinero: "/img/oficio1.png",
+  Gasista: "/img/gasista.jpeg",
+  Pintor: "/img/oficio1.png",
+  Cerrajero: "/img/cerrajero.jpeg",
+  Metalurgico: "/img/metalurgico.jpeg",
+  Mecanico: "/img/ferretero.jpeg",
+  default: "/img/avatarImage.jpg",
+};
+
+export const ProfessionalProfile = () => {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [professional, setProfessional] = useState(null);
+  const [reviews, setReviews] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    Promise.all([
+      fetch(`http://localhost:3000/professionals/${id}`).then(r => r.json()),
+      fetch(`http://localhost:3000/professionals/${id}/reviews`).then(r => r.json()),
+    ])
+      .then(([proData, reviewData]) => {
+        if (proData.professional) {
+          setProfessional(proData.professional);
+          setReviews(reviewData.reviews || []);
+        } else {
+          setError("Profesional no encontrado.");
+        }
+      })
+      .catch(() => setError("Error al cargar el perfil."))
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  if (loading) return <><Navbar /><StatusMessage>Cargando...</StatusMessage><Footer /></>;
+  if (error)   return <><Navbar /><StatusMessage>{error}</StatusMessage><Footer /></>;
+
+  const image = specialtyImages[professional.specialty] || specialtyImages.default;
+  const whatsappUrl = `https://wa.me/54${professional.phoneNumber}?text=Hola%20${professional.firstName},%20te%20contacto%20desde%20TuOficio.com`;
+
+  return (
+    <div>
+      <Navbar />
+      <Wrapper>
+        <Card>
+          {/* Header */}
+          <Header>
+            <ProfileImage src={image} alt={professional.specialty} />
+            <HeaderInfo>
+              <Name>{professional.firstName} {professional.lastName}</Name>
+              <SpecialtyBadge>{professional.specialty}</SpecialtyBadge>
+              <BackButton onClick={() => navigate(-1)}>← Volver</BackButton>
+            </HeaderInfo>
+          </Header>
+
+          <Divider />
+
+          {/* Info */}
+          <InfoGrid>
+            <InfoBlock>
+              <InfoIcon>📍</InfoIcon>
+              <InfoContent>
+                <InfoLabel>Ubicación</InfoLabel>
+                <InfoValue>{professional.address}</InfoValue>
+              </InfoContent>
+            </InfoBlock>
+
+            <InfoBlock>
+              <InfoIcon>📞</InfoIcon>
+              <InfoContent>
+                <InfoLabel>Teléfono</InfoLabel>
+                <InfoValue>{professional.phoneNumber}</InfoValue>
+              </InfoContent>
+            </InfoBlock>
+
+            <InfoBlock>
+              <InfoIcon>✉️</InfoIcon>
+              <InfoContent>
+                <InfoLabel>Email</InfoLabel>
+                <InfoValue>{professional.email}</InfoValue>
+              </InfoContent>
+            </InfoBlock>
+
+            {professional.yearsOfExperience && (
+              <InfoBlock>
+                <InfoIcon>⏱</InfoIcon>
+                <InfoContent>
+                  <InfoLabel>Años de experiencia</InfoLabel>
+                  <InfoValue>{professional.yearsOfExperience} años</InfoValue>
+                </InfoContent>
+              </InfoBlock>
+            )}
+
+            {professional.registrationNumber && (
+              <InfoBlock>
+                <InfoIcon>🪪</InfoIcon>
+                <InfoContent>
+                  <InfoLabel>Número de matrícula</InfoLabel>
+                  <InfoValue>{professional.registrationNumber}</InfoValue>
+                </InfoContent>
+              </InfoBlock>
+            )}
+
+            <InfoBlock>
+              <InfoIcon>👤</InfoIcon>
+              <InfoContent>
+                <InfoLabel>Usuario</InfoLabel>
+                <InfoValue>@{professional.userName}</InfoValue>
+              </InfoContent>
+            </InfoBlock>
+          </InfoGrid>
+
+          <Divider />
+
+          {/* Reseñas */}
+          {reviews.length > 0 && (
+            <>
+              <Divider />
+              <ReviewsTitle>⭐ Últimas reseñas</ReviewsTitle>
+              <ReviewsGrid>
+                {reviews.map((review) => (
+                  <ReviewCard key={review.id}>
+                    <ReviewHeader>
+                      <ReviewClient>{review.clientName}</ReviewClient>
+                      <Stars>{'★'.repeat(review.rating)}{'☆'.repeat(5 - review.rating)}</Stars>
+                    </ReviewHeader>
+                    <ReviewComment>"{review.comment}"</ReviewComment>
+                    <ReviewDate>
+                      {new Date(review.createdAt).toLocaleDateString('es-AR', {
+                        year: 'numeric', month: 'long', day: 'numeric'
+                      })}
+                    </ReviewDate>
+                  </ReviewCard>
+                ))}
+              </ReviewsGrid>
+            </>
+          )}
+
+          {/* Acciones */}
+          <Actions>
+            <WhatsAppButton href={whatsappUrl} target="_blank" rel="noreferrer">
+              💬 Contactar por WhatsApp
+            </WhatsAppButton>
+            <EmailButton href={`mailto:${professional.email}`}>
+              ✉️ Enviar Email
+            </EmailButton>
+          </Actions>
+        </Card>
+      </Wrapper>
+      <Footer />
+    </div>
+  );
+};
+
+const Wrapper = styled.div`
+  min-height: 80vh;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 3rem 1rem;
+  background-color: #f5f5f5;
+`;
+
+const Card = styled.div`
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 4px 24px rgba(0,0,0,0.1);
+  padding: 2.5rem;
+  width: 100%;
+  max-width: 620px;
+`;
+
+const Header = styled.div`
+  display: flex;
+  gap: 2rem;
+  align-items: center;
+
+  @media (max-width: 500px) {
+    flex-direction: column;
+    text-align: center;
+  }
+`;
+
+const ProfileImage = styled.img`
+  width: 130px;
+  height: 130px;
+  object-fit: cover;
+  border-radius: 50%;
+  border: 4px solid #FF6922;
+  flex-shrink: 0;
+`;
+
+const HeaderInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+`;
+
+const Name = styled.h1`
+  color: #0E2E50;
+  font-size: 1.8rem;
+  margin: 0;
+`;
+
+const SpecialtyBadge = styled.span`
+  background-color: #FF6922;
+  color: #fff;
+  font-size: 0.9rem;
+  font-weight: 600;
+  padding: 0.3rem 1rem;
+  border-radius: 20px;
+  align-self: flex-start;
+`;
+
+const BackButton = styled.button`
+  background: none;
+  border: none;
+  color: #48cae4;
+  cursor: pointer;
+  font-size: 0.9rem;
+  padding: 0;
+  text-align: left;
+  &:hover { text-decoration: underline; }
+`;
+
+const Divider = styled.hr`
+  border: none;
+  border-top: 1px solid #eee;
+  margin: 1.5rem 0;
+`;
+
+const InfoGrid = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.2rem;
+
+  @media (max-width: 500px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const InfoBlock = styled.div`
+  display: flex;
+  gap: 0.8rem;
+  align-items: flex-start;
+`;
+
+const InfoIcon = styled.span`
+  font-size: 1.3rem;
+  margin-top: 2px;
+`;
+
+const InfoContent = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const InfoLabel = styled.span`
+  font-size: 0.75rem;
+  color: #999;
+  font-weight: 600;
+  text-transform: uppercase;
+`;
+
+const InfoValue = styled.span`
+  font-size: 0.95rem;
+  color: #333;
+  font-weight: 500;
+`;
+
+const Actions = styled.div`
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+`;
+
+const WhatsAppButton = styled.a`
+  flex: 1;
+  display: block;
+  text-align: center;
+  background-color: #25D366;
+  color: #fff;
+  padding: 0.85rem;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background-color 0.2s;
+  &:hover { background-color: #1ebe5d; }
+`;
+
+const EmailButton = styled.a`
+  flex: 1;
+  display: block;
+  text-align: center;
+  background-color: #0E2E50;
+  color: #fff;
+  padding: 0.85rem;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background-color 0.2s;
+  &:hover { background-color: #48cae4; }
+`;
+
+const StatusMessage = styled.p`
+  text-align: center;
+  padding: 4rem;
+  color: #666;
+  font-size: 1.2rem;
+`;
+
+const ReviewsTitle = styled.h3`
+  color: #0E2E50;
+  font-size: 1.1rem;
+  margin-bottom: 1rem;
+`;
+
+const ReviewsGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+
+  @media (max-width: 600px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const ReviewCard = styled.div`
+  background: #f9f9f9;
+  border-radius: 10px;
+  padding: 1rem;
+  border-left: 4px solid #FF6922;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+`;
+
+const ReviewHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const ReviewClient = styled.span`
+  font-weight: 700;
+  color: #0E2E50;
+  font-size: 0.88rem;
+`;
+
+const Stars = styled.span`
+  color: #FF6922;
+  font-size: 0.9rem;
+  letter-spacing: 1px;
+`;
+
+const ReviewComment = styled.p`
+  color: #444;
+  font-size: 0.85rem;
+  font-style: italic;
+  line-height: 1.4;
+  margin: 0;
+`;
+
+const ReviewDate = styled.span`
+  color: #aaa;
+  font-size: 0.75rem;
+`;

--- a/frontend/src/components/Recommend/Recommend.jsx
+++ b/frontend/src/components/Recommend/Recommend.jsx
@@ -1,104 +1,140 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import styled from "styled-components";
+import { useNavigate } from "react-router-dom";
+
+const specialtyImages = {
+  Plomero: "/img/plomero.jpeg",
+  Electricista: "/img/electricista.jpeg",
+  Carpintero: "/img/oficio1.png",
+  Albanil: "/img/albanil.jpeg",
+  Jardinero: "/img/oficio1.png",
+  Gasista: "/img/gasista.jpeg",
+  Pintor: "/img/oficio1.png",
+  Cerrajero: "/img/cerrajero.jpeg",
+  Metalurgico: "/img/metalurgico.jpeg",
+  Mecanico: "/img/ferretero.jpeg",
+  default: "/img/avatarImage.jpg",
+};
+
+const packages = [
+  "Lo más popular",
+  "Los más recomendados",
+  "Según ubicación",
+  "Por especialidad",
+];
+
 export const Recommend = () => {
-  const data = [
-    {
-      image: "../img/cerrajero.jpeg",
-      title: "Cerrajero",
-      subTitle: "Soy un cerrajero experimentado que se especializa en solucionar problemas de cerrajería. Brindo servicios confiables de apertura, reparación y reemplazo de cerraduras para garantizar la seguridad de mis clientes",
-      cost: "$10000",
-      duration: "Calificacion",
-    },
-    {
-      image: "../img/plomero.jpeg",
-      title: "Plomero",
-      subTitle: "Soy un plomero con experiencia en instalación y reparación de fontanería, listo para solucionar tus problemas de agua y tuberías de manera eficiente.",
-      cost: "$54200",
-      duration: "Calificacion",
-    },
-    {
-      image: "../img/gasista.jpeg",
-      title: "Gasista",
-      subTitle: "Soy un gasista con experiencia en instalación y mantenimiento de sistemas de gas para tu tranquilidad y seguridad.",
-      cost: "$45500",
-      duration: "Calificacion",
-    },
-    {
-      image: "../img/electricista.jpeg",
-      title: "Electricista",
-      subTitle: "Soy un electricista experto en instalación y reparación de sistemas eléctricos para hogares y negocios, garantizando seguridad y eficiencia.",
-      cost: "$24100",
-      duration: "Calificacion",
-    },
-    {
-      image: "../img/metalurgico.jpeg",
-      title: "Metalurgico",
-      subTitle: "Soy un metalúrgico con experiencia en trabajar con metales para crear productos duraderos y de calidad.",
-      cost: "$95400",
-      duration: "Calificacion",
-    },
-    {
-      image: "../img/albañil.jpeg",
-      title: "Albañil",
-      subTitle: "Soy un albañil con experiencia en construcción y renovación, enfocado en crear estructuras sólidas y acabados de calidad",
-      cost: "$38800",
-      duration: "Calificacion",
-    },
-  ];
+  const navigate = useNavigate();
+  const [active, setActive] = useState(0);
+  const [professionals, setProfessionals] = useState([]);
+  const [loading, setLoading] = useState(false);
 
-  const packages = [
-    "Lo mas popular",
-    "Los mas recomentados",
-    "Según ubicación ",
-    "Por precios",
-  ];
+  useEffect(() => {
+    loadTab(active);
+  }, [active]);
 
-  const [active, setActive] = useState(1);
+  const loadTab = async (tab) => {
+    setLoading(true);
+    try {
+      let results = [];
+
+      if (tab === 0) {
+        // Lo más popular: búsqueda amplia, shuffle
+        const res = await fetch("http://localhost:3000/search?q=a");
+        const data = await res.json();
+        results = (data.results || []).sort(() => Math.random() - 0.5).slice(0, 6);
+
+      } else if (tab === 1) {
+        // Los más recomendados: buscar todos y ordenar por yearsOfExperience como proxy
+        const res = await fetch("http://localhost:3000/search?q=a");
+        const data = await res.json();
+        results = (data.results || [])
+          .sort((a, b) => (b.yearsOfExperience || 0) - (a.yearsOfExperience || 0))
+          .slice(0, 6);
+
+      } else if (tab === 2) {
+        // Según ubicación: buscar por Mendoza
+        const res = await fetch("http://localhost:3000/search?q=Mendoza");
+        const data = await res.json();
+        results = (data.results || []).slice(0, 6);
+
+      } else if (tab === 3) {
+        // Por especialidad: 1 de cada tipo
+        const specialties = ["Albanil", "Electricista", "Plomero", "Mecanico", "Cerrajero", "Gasista"];
+        for (const specialty of specialties) {
+          const res = await fetch(`http://localhost:3000/search?q=${specialty}`);
+          const data = await res.json();
+          if (data.results?.length > 0) results.push(data.results[0]);
+        }
+      }
+
+      setProfessionals(results);
+    } catch (err) {
+      console.error("Error cargando recomendados:", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getImage = (pro) => specialtyImages[pro.specialty] || specialtyImages.default;
+
   return (
     <Section id="recommend">
       <div className="title">
         <h2>Lo más recomendado</h2>
       </div>
+
       <div className="packages">
         <ul>
-          {packages.map((pkg, index) => {
-            return (
-              <li
-                className={active === index + 1 ? "active" : ""}
-                onClick={() => setActive(index + 1)}
-              >
-                {pkg}
-              </li>
-            );
-          })}
+          {packages.map((pkg, index) => (
+            <li
+              key={index}
+              className={active === index ? "active" : ""}
+              onClick={() => setActive(index)}
+            >
+              {pkg}
+            </li>
+          ))}
         </ul>
       </div>
+
       <div className="destinations">
-        {data.map((destination) => {
-          return (
-            <div className="destination">
-              <img src={destination.image} alt="" />
-              <h3>{destination.title}</h3>
-              <p>{destination.subTitle}</p>
-              <div className="info">
-                <div className="services">
-                  <img src={"../img/info1.png"} alt="" />
-                  <img src={"../img/info2.png"} alt="" />
-                  <img src={"../img/info3.png"} alt="" />
-                </div>
-                <h4>{destination.cost}</h4>
+        {loading && <LoadingMsg>Cargando...</LoadingMsg>}
+
+        {!loading && professionals.map((pro) => (
+          <div
+            className="destination"
+            key={pro.id}
+            onClick={() => navigate(`/professional/${pro.id}`)}
+          >
+            <img src={getImage(pro)} alt={pro.specialty} />
+            <h3>{pro.firstName} {pro.lastName}</h3>
+            <p>{pro.specialty} · {pro.address}</p>
+            <div className="info">
+              <div className="services">
+                <img src={"/img/info1.png"} alt="" />
+                <img src={"/img/info2.png"} alt="" />
+                <img src={"/img/info3.png"} alt="" />
               </div>
-              <div className="distance">
-                <span>100 Puntos</span>
-                <span>{destination.duration}</span>
-              </div>
+              <h4>Ver perfil →</h4>
             </div>
-          );
-        })}
+            <div className="distance">
+              <span>⏱ {pro.yearsOfExperience || '-'} años exp.</span>
+              <span>📍 {pro.address?.split(',')[0]}</span>
+            </div>
+          </div>
+        ))}
       </div>
     </Section>
   );
-}
+};
+
+const LoadingMsg = styled.p`
+  text-align: center;
+  color: #666;
+  padding: 2rem;
+  grid-column: 1 / -1;
+`;
 
 const Section = styled.section`
   padding: 2rem 0;
@@ -116,9 +152,14 @@ const Section = styled.section`
       li {
         padding: 1rem 2rem;
         border-bottom: 0.1rem solid black;
+        cursor: pointer;
+        transition: 0.2s;
+        &:hover { color: #FF6922; }
       }
       .active {
-        border-bottom: 0.5rem solid #8338ec;
+        border-bottom: 0.5rem solid #FF6922;
+        color: #FF6922;
+        font-weight: 600;
       }
     }
   }
@@ -135,16 +176,23 @@ const Section = styled.section`
       background-color: #8338ec14;
       border-radius: 1rem;
       transition: 0.3s ease-in-out;
+      cursor: pointer;
       &:hover {
         transform: translateX(0.4rem) translateY(-1rem);
         box-shadow: rgba(0, 0, 0, 0.35) 0px 5px 15px;
       }
       img {
         width: 100%;
+        height: 180px;
+        object-fit: cover;
+        border-radius: 0.5rem;
       }
+      h3 { color: #0E2E50; margin: 0; }
+      p { font-size: 0.9rem; color: #555; margin: 0; }
       .info {
         display: flex;
         align-items: center;
+        justify-content: space-between;
         .services {
           display: flex;
           gap: 0.3rem;
@@ -152,30 +200,25 @@ const Section = styled.section`
             border-radius: 1rem;
             background-color: #4d2ddb84;
             width: 2rem;
-            /* padding: 1rem; */
+            height: auto;
             padding: 0.3rem 0.4rem;
           }
         }
-        display: flex;
-        justify-content: space-between;
+        h4 { color: #FF6922; font-size: 0.9rem; margin: 0; }
       }
       .distance {
         display: flex;
         justify-content: space-between;
+        font-size: 0.82rem;
+        color: #666;
       }
     }
   }
   @media screen and (min-width: 280px) and (max-width: 768px) {
     .packages {
       ul {
-        li {
-          padding: 0 0.5rem;
-          font-size: 2vh;
-          padding-bottom: 1rem;
-        }
-        .active {
-          border-bottom-width: 0.3rem;
-        }
+        li { padding: 0 0.5rem; font-size: 2vh; padding-bottom: 1rem; }
+        .active { border-bottom-width: 0.3rem; }
       }
     }
     .destinations {

--- a/frontend/src/components/SearchResults/SearchResults.jsx
+++ b/frontend/src/components/SearchResults/SearchResults.jsx
@@ -1,135 +1,291 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import styled from "styled-components";
+import { useSearchParams, useNavigate } from "react-router-dom";
 import { ScrollToTop } from '../ScrollToTop/ScrollToTop';
 import { Navbar } from '../Navbar/Navbar';
 import { Footer } from '../Footer/Footer';
 
-export const SearchResults = () => {
-  const data = [
-    {
-      image: "../img/cerrajero.jpeg",
-      title: "Cerrajero",
-      subTitle: "Soy un cerrajero experimentado que se especializa en solucionar problemas de cerrajería. Brindo servicios confiables de apertura, reparación y reemplazo de cerraduras para garantizar la seguridad de mis clientes",
-      duration: "Calificación",
-    },
-    {
-      image: "../img/gasista.jpeg",
-      title: "Gasista",
-      subTitle: "Soy un gasista con experiencia en instalación y mantenimiento de sistemas de gas para tu tranquilidad y seguridad.",
-      duration: "Calificación",
-    },
-  ];
+const specialtyImages = {
+  Plomero: "/img/plomero.jpeg",
+  Electricista: "/img/electricista.jpeg",
+  Carpintero: "/img/oficio1.png",
+  Albanil: "/img/albanil.jpeg",
+  Jardinero: "/img/oficio1.png",
+  Gasista: "/img/gasista.jpeg",
+  Pintor: "/img/oficio1.png",
+  Cerrajero: "/img/cerrajero.jpeg",
+  Soldador: "/img/metalurgico.jpeg",
+  default: "/img/avatarImage.jpg",
+};
 
-  const [active, setActive] = useState(1);
+export const SearchResults = () => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const [professionals, setProfessionals] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [searchInput, setSearchInput] = useState('');
+  const query = searchParams.get('q') || '';
+
+  useEffect(() => {
+    setSearchInput(query);
+    if (query) fetchResults(query);
+  }, [query]);
+
+  const fetchResults = async (q) => {
+    setLoading(true);
+    try {
+      const response = await fetch(`http://localhost:3000/search?q=${encodeURIComponent(q)}`);
+      const data = await response.json();
+      setProfessionals(data.results || []);
+    } catch (err) {
+      console.error('Error al buscar:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSearch = (e) => {
+    e.preventDefault();
+    if (searchInput.trim()) {
+      navigate(`/searchResults?q=${encodeURIComponent(searchInput.trim())}`);
+    }
+  };
+
+  const getImage = (professional) => {
+    return specialtyImages[professional.specialty] || specialtyImages.default;
+  };
 
   return (
     <div>
       <ScrollToTop />
       <Navbar />
-      <Section id="recommend">
-        <div className="title">
-          <h2>Profesionales cerca de tu búsqueda.</h2>
-        </div>
-        <br />
-        <br />
-        <div className="destinations">
-          <div className="destinations-left">
-            {data.map((destination, index) => {
-              return (
-                <div className="destination-container" key={index}>
-                  <div className="destination">
-                    <img src={destination.image} alt="" />
-                    <h3>{destination.title}</h3>
-                    <p>{destination.subTitle}</p>
-                    <div className="info">
-                      <img src="../img/calificacion.svg" alt="" />
-                      <h4>{destination.duration}</h4>
-                    </div>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-          <div className="map">
-            <img src="" alt="" />
-          </div>
-        </div>
+
+      <Section>
+        {/* Barra de búsqueda */}
+        <SearchBar onSubmit={handleSearch}>
+          <SearchInput
+            type="text"
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            placeholder="Buscar profesional, especialidad..."
+          />
+          <SearchButton type="submit">Buscar</SearchButton>
+        </SearchBar>
+
+        <ResultsTitle>
+          {query
+            ? `Profesionales para "${query}" (${professionals.length} resultados)`
+            : 'Todos los profesionales'}
+        </ResultsTitle>
+
+        <Content>
+          {/* Lista de resultados */}
+          <ResultsList>
+            {loading && <StatusMessage>Buscando...</StatusMessage>}
+
+            {!loading && professionals.length === 0 && (
+              <StatusMessage>No se encontraron profesionales para tu búsqueda.</StatusMessage>
+            )}
+
+            {!loading && professionals.map((pro) => (
+              <ProfessionalCard key={pro.id}>
+                <CardImage src={getImage(pro)} alt={pro.specialty} />
+                <CardBody>
+                  <CardName>{pro.firstName} {pro.lastName}</CardName>
+                  {pro.specialty && <CardSpecialty>{pro.specialty}</CardSpecialty>}
+                  <CardInfo>
+                    <InfoItem>📍 {pro.address}</InfoItem>
+                    {pro.yearsOfExperience && (
+                      <InfoItem>⏱ {pro.yearsOfExperience} años de experiencia</InfoItem>
+                    )}
+                    <InfoItem>📞 {pro.phoneNumber}</InfoItem>
+                  </CardInfo>
+                  <ContactButton href={`mailto:${pro.email}`}>
+                    Contactar
+                  </ContactButton>
+                </CardBody>
+              </ProfessionalCard>
+            ))}
+          </ResultsList>
+
+          {/* Mapa */}
+          <MapContainer>
+            <MapImage src="/img/mapa.jpg" alt="Mapa de resultados" />
+          </MapContainer>
+        </Content>
       </Section>
+
       <Footer />
     </div>
   );
 };
 
 const Section = styled.section`
-  padding: 1rem 0;
-  .title {
-    text-align: center;
+  padding: 2rem 4%;
+  min-height: 70vh;
+`;
+
+const SearchBar = styled.form`
+  display: flex;
+  gap: 0.8rem;
+  margin-bottom: 1.5rem;
+  max-width: 600px;
+`;
+
+const SearchInput = styled.input`
+  flex: 1;
+  padding: 0.75rem 1rem;
+  border: 1.5px solid #ccc;
+  border-radius: 8px;
+  font-size: 1rem;
+
+  &:focus {
+    outline: none;
+    border-color: #FF6922;
   }
-  .destinations {
-    display: flex;
-    justify-content: stretch;
+`;
+
+const SearchButton = styled.button`
+  background-color: #FF6922;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s;
+
+  &:hover {
+    background-color: #e55a10;
   }
-  .destinations-left {
-    width: 25%;
-    display: flex;
+`;
+
+const ResultsTitle = styled.h2`
+  color: #0E2E50;
+  margin-bottom: 1.5rem;
+  font-size: 1.3rem;
+`;
+
+const Content = styled.div`
+  display: flex;
+  gap: 2rem;
+  align-items: flex-start;
+
+  @media (max-width: 768px) {
     flex-direction: column;
-    align-items: flex-start;
   }
-  .destination-container {
-    margin-bottom: 2rem;
+`;
+
+const ResultsList = styled.div`
+  width: 35%;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  @media (max-width: 768px) {
+    width: 100%;
   }
-  .destination {
-    padding: 1rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    background-color: #8338ec14;
-    border-radius: 1rem;
-    transition: 0.3s ease-in-out;
-    &:hover {
-      transform: translateX(0.4rem) translateY(-1rem);
-      box-shadow: rgba(0, 0, 0, 0.35) 0px 5px 15px;
-    }
-    img {
-      width: 100%;
-    }
-    .info {
-      display: flex;
-      align-items: center;
-      .services {
-        display: flex;
-        gap: 0.3rem;
-        img {
-          border-radius: 1rem;
-          background-color: #4d2ddb84;
-          width: 2rem;
-          padding: 0.3rem 0.4rem;
-        }
-      }
-    }
+`;
+
+const StatusMessage = styled.p`
+  color: #666;
+  text-align: center;
+  padding: 2rem;
+`;
+
+const ProfessionalCard = styled.div`
+  display: flex;
+  gap: 1rem;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 12px rgba(0,0,0,0.08);
+  padding: 1rem;
+  transition: transform 0.2s, box-shadow 0.2s;
+  cursor: pointer;
+
+  &:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 6px 20px rgba(0,0,0,0.12);
   }
-  .map {
-    width: 80%;
-    border: 2px solid #000;
-    background-image: url("../img/mapa.jpg");
-    background-size: cover;
-    padding: 2.5%;
-    margin-top:1%;
-    margin-right:4%;
-    margin-left:4%;
+`;
+
+const CardImage = styled.img`
+  width: 80px;
+  height: 80px;
+  object-fit: cover;
+  border-radius: 8px;
+  flex-shrink: 0;
+`;
+
+const CardBody = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+`;
+
+const CardName = styled.h3`
+  color: #0E2E50;
+  font-size: 1rem;
+  margin: 0;
+`;
+
+const CardSpecialty = styled.span`
+  background-color: #FF6922;
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.2rem 0.6rem;
+  border-radius: 20px;
+  align-self: flex-start;
+`;
+
+const CardInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  margin-top: 0.3rem;
+`;
+
+const InfoItem = styled.span`
+  font-size: 0.82rem;
+  color: #555;
+`;
+
+const ContactButton = styled.a`
+  margin-top: 0.5rem;
+  align-self: flex-start;
+  background-color: #0E2E50;
+  color: #fff;
+  padding: 0.4rem 1rem;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  text-decoration: none;
+  transition: background-color 0.2s;
+
+  &:hover {
+    background-color: #48cae4;
   }
-  @media screen and (max-width: 768px) {
-    .destinations {
-      flex-direction: column;
-      align-items: center;
-    }
-    .destinations-left {
-      width: 100%;
-    }
-    .map {
-      width: 100%;
-      margin-top: 1rem;
-    }
+`;
+
+const MapContainer = styled.div`
+  flex: 1;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 2px 12px rgba(0,0,0,0.1);
+  position: sticky;
+  top: 1rem;
+
+  @media (max-width: 768px) {
+    width: 100%;
+    position: static;
   }
-};
-`
+`;
+
+const MapImage = styled.img`
+  width: 100%;
+  height: 520px;
+  object-fit: cover;
+  display: block;
+`;

--- a/frontend/src/components/SearchResults/SearchResults.jsx
+++ b/frontend/src/components/SearchResults/SearchResults.jsx
@@ -1,9 +1,20 @@
 import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 import { useSearchParams, useNavigate } from "react-router-dom";
+import { MapContainer, TileLayer, Marker, Popup } from "react-leaflet";
+import L from "leaflet";
+import "leaflet/dist/leaflet.css";
 import { ScrollToTop } from '../ScrollToTop/ScrollToTop';
 import { Navbar } from '../Navbar/Navbar';
 import { Footer } from '../Footer/Footer';
+
+// Fix leaflet default icon
+delete L.Icon.Default.prototype._getIconUrl;
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png",
+  iconUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png",
+  shadowUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png",
+});
 
 const specialtyImages = {
   Plomero: "/img/plomero.jpeg",
@@ -18,12 +29,32 @@ const specialtyImages = {
   default: "/img/avatarImage.jpg",
 };
 
+// Geocodifica una dirección usando Nominatim (OpenStreetMap, gratuito)
+const geocode = async (address) => {
+  try {
+    const res = await fetch(
+      `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(address + ", Mendoza, Argentina")}&format=json&limit=1`,
+      { headers: { "Accept-Language": "es" } }
+    );
+    const data = await res.json();
+    if (data.length > 0) {
+      return { lat: parseFloat(data[0].lat), lng: parseFloat(data[0].lon) };
+    }
+  } catch (e) {}
+  return null;
+};
+
+// Centro por defecto: Mendoza, Argentina
+const MENDOZA_CENTER = [-32.8908, -68.8272];
+
 export const SearchResults = () => {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const [professionals, setProfessionals] = useState([]);
+  const [markers, setMarkers] = useState([]);
   const [loading, setLoading] = useState(false);
   const [searchInput, setSearchInput] = useState('');
+  const [selectedPro, setSelectedPro] = useState(null);
   const query = searchParams.get('q') || '';
 
   useEffect(() => {
@@ -33,15 +64,28 @@ export const SearchResults = () => {
 
   const fetchResults = async (q) => {
     setLoading(true);
+    setMarkers([]);
     try {
       const response = await fetch(`http://localhost:3000/search?q=${encodeURIComponent(q)}`);
       const data = await response.json();
-      setProfessionals(data.results || []);
+      const results = data.results || [];
+      setProfessionals(results);
+      geocodeAll(results);
     } catch (err) {
       console.error('Error al buscar:', err);
     } finally {
       setLoading(false);
     }
+  };
+
+  const geocodeAll = async (pros) => {
+    const located = [];
+    for (const pro of pros) {
+      const coords = await geocode(pro.address);
+      if (coords) located.push({ ...pro, coords });
+      await new Promise(r => setTimeout(r, 300)); // Rate limit Nominatim
+    }
+    setMarkers(located);
   };
 
   const handleSearch = (e) => {
@@ -51,9 +95,11 @@ export const SearchResults = () => {
     }
   };
 
-  const getImage = (professional) => {
-    return specialtyImages[professional.specialty] || specialtyImages.default;
-  };
+  const getImage = (pro) => specialtyImages[pro.specialty] || specialtyImages.default;
+
+  const mapCenter = markers.length > 0
+    ? [markers[0].coords.lat, markers[0].coords.lng]
+    : MENDOZA_CENTER;
 
   return (
     <div>
@@ -61,7 +107,6 @@ export const SearchResults = () => {
       <Navbar />
 
       <Section>
-        {/* Barra de búsqueda */}
         <SearchBar onSubmit={handleSearch}>
           <SearchInput
             type="text"
@@ -88,7 +133,11 @@ export const SearchResults = () => {
             )}
 
             {!loading && professionals.map((pro) => (
-              <ProfessionalCard key={pro.id}>
+              <ProfessionalCard
+                key={pro.id}
+                $selected={selectedPro?.id === pro.id}
+                onClick={() => setSelectedPro(pro)}
+              >
                 <CardImage src={getImage(pro)} alt={pro.specialty} />
                 <CardBody>
                   <CardName>{pro.firstName} {pro.lastName}</CardName>
@@ -100,18 +149,79 @@ export const SearchResults = () => {
                     )}
                     <InfoItem>📞 {pro.phoneNumber}</InfoItem>
                   </CardInfo>
-                  <ContactButton href={`mailto:${pro.email}`}>
-                    Contactar
-                  </ContactButton>
+                  <CardActions>
+                    <ContactButton href={`mailto:${pro.email}`}>
+                      ✉️ Email
+                    </ContactButton>
+                    <ProfileButton href={`/professional/${pro.id}`}>
+                      👤 Ver perfil
+                    </ProfileButton>
+                  </CardActions>
                 </CardBody>
               </ProfessionalCard>
             ))}
           </ResultsList>
 
-          {/* Mapa */}
-          <MapContainer>
-            <MapImage src="/img/mapa.jpg" alt="Mapa de resultados" />
-          </MapContainer>
+          {/* Mapa Leaflet */}
+          <MapWrapper>
+            <MapContainer
+              center={mapCenter}
+              zoom={12}
+              style={{ width: "100%", height: "520px", borderRadius: "12px" }}
+            >
+              <TileLayer
+                attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+                url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+              />
+              {markers.map((pro) => (
+                <Marker
+                  key={pro.id}
+                  position={[pro.coords.lat, pro.coords.lng]}
+                >
+                  <Popup>
+                    <strong>{pro.firstName} {pro.lastName}</strong><br />
+                    {pro.specialty}<br />
+                    📍 {pro.address}<br />
+                    📞 {pro.phoneNumber}<br /><br />
+                    <div style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}>
+                      <a
+                        href={`https://wa.me/54${pro.phoneNumber}?text=Hola%20${pro.firstName},%20te%20contacto%20desde%20TuOficio.com`}
+                        target="_blank"
+                        rel="noreferrer"
+                        style={{
+                          display: "inline-block",
+                          backgroundColor: "#25D366",
+                          color: "#fff",
+                          padding: "6px 12px",
+                          borderRadius: "6px",
+                          textDecoration: "none",
+                          fontWeight: "bold",
+                          fontSize: "13px"
+                        }}
+                      >
+                        💬 WhatsApp
+                      </a>
+                      <a
+                        href={`/professional/${pro.id}`}
+                        style={{
+                          display: "inline-block",
+                          backgroundColor: "#0E2E50",
+                          color: "#fff",
+                          padding: "6px 12px",
+                          borderRadius: "6px",
+                          textDecoration: "none",
+                          fontWeight: "bold",
+                          fontSize: "13px"
+                        }}
+                      >
+                        👤 Ver perfil
+                      </a>
+                    </div>
+                  </Popup>
+                </Marker>
+              ))}
+            </MapContainer>
+          </MapWrapper>
         </Content>
       </Section>
 
@@ -138,7 +248,6 @@ const SearchInput = styled.input`
   border: 1.5px solid #ccc;
   border-radius: 8px;
   font-size: 1rem;
-
   &:focus {
     outline: none;
     border-color: #FF6922;
@@ -155,10 +264,7 @@ const SearchButton = styled.button`
   font-weight: 600;
   cursor: pointer;
   transition: background-color 0.2s;
-
-  &:hover {
-    background-color: #e55a10;
-  }
+  &:hover { background-color: #e55a10; }
 `;
 
 const ResultsTitle = styled.h2`
@@ -171,10 +277,7 @@ const Content = styled.div`
   display: flex;
   gap: 2rem;
   align-items: flex-start;
-
-  @media (max-width: 768px) {
-    flex-direction: column;
-  }
+  @media (max-width: 768px) { flex-direction: column; }
 `;
 
 const ResultsList = styled.div`
@@ -182,10 +285,7 @@ const ResultsList = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1rem;
-
-  @media (max-width: 768px) {
-    width: 100%;
-  }
+  @media (max-width: 768px) { width: 100%; }
 `;
 
 const StatusMessage = styled.p`
@@ -201,9 +301,9 @@ const ProfessionalCard = styled.div`
   border-radius: 12px;
   box-shadow: 0 2px 12px rgba(0,0,0,0.08);
   padding: 1rem;
-  transition: transform 0.2s, box-shadow 0.2s;
   cursor: pointer;
-
+  transition: transform 0.2s, box-shadow 0.2s;
+  border: 2px solid ${({ $selected }) => $selected ? '#FF6922' : 'transparent'};
   &:hover {
     transform: translateY(-3px);
     box-shadow: 0 6px 20px rgba(0,0,0,0.12);
@@ -253,39 +353,44 @@ const InfoItem = styled.span`
   color: #555;
 `;
 
-const ContactButton = styled.a`
+const CardActions = styled.div`
+  display: flex;
+  gap: 0.5rem;
   margin-top: 0.5rem;
-  align-self: flex-start;
-  background-color: #0E2E50;
-  color: #fff;
-  padding: 0.4rem 1rem;
-  border-radius: 6px;
-  font-size: 0.85rem;
-  text-decoration: none;
-  transition: background-color 0.2s;
-
-  &:hover {
-    background-color: #48cae4;
-  }
+  flex-wrap: wrap;
 `;
 
-const MapContainer = styled.div`
+const ContactButton = styled.a`
+  background-color: #0E2E50;
+  color: #fff;
+  padding: 0.4rem 0.8rem;
+  border-radius: 6px;
+  font-size: 0.82rem;
+  text-decoration: none;
+  transition: background-color 0.2s;
+  &:hover { background-color: #48cae4; }
+`;
+
+const ProfileButton = styled.a`
+  background-color: #FF6922;
+  color: #fff;
+  padding: 0.4rem 0.8rem;
+  border-radius: 6px;
+  font-size: 0.82rem;
+  text-decoration: none;
+  transition: background-color 0.2s;
+  &:hover { background-color: #e55a10; }
+`;
+
+const MapWrapper = styled.div`
   flex: 1;
   border-radius: 12px;
   overflow: hidden;
   box-shadow: 0 2px 12px rgba(0,0,0,0.1);
   position: sticky;
   top: 1rem;
-
   @media (max-width: 768px) {
     width: 100%;
     position: static;
   }
-`;
-
-const MapImage = styled.img`
-  width: 100%;
-  height: 520px;
-  object-fit: cover;
-  display: block;
 `;

--- a/frontend/src/components/SignUpForm/SignUpForm.jsx
+++ b/frontend/src/components/SignUpForm/SignUpForm.jsx
@@ -1,207 +1,480 @@
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
-import './SignUpForm.css';
+import { Link, useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #f5f5f5;
+  padding: 2rem 0;
+`;
+
+const Card = styled.div`
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 4px 24px rgba(0,0,0,0.1);
+  padding: 2.5rem;
+  width: 100%;
+  max-width: 480px;
+`;
+
+const Title = styled.h2`
+  color: #0E2E50;
+  text-align: center;
+  margin-bottom: 2rem;
+  font-size: 1.8rem;
+`;
+
+const FormGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1.2rem;
+`;
+
+const Row = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+`;
+
+const Label = styled.label`
+  color: #0E2E50;
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+  font-size: 0.9rem;
+`;
+
+const Input = styled.input`
+  padding: 0.75rem 1rem;
+  border: 1.5px solid ${({ $error }) => $error ? '#e53935' : '#ccc'};
+  border-radius: 8px;
+  font-size: 1rem;
+  transition: border-color 0.2s;
+
+  &:focus {
+    outline: none;
+    border-color: #FF6922;
+  }
+`;
+
+const Select = styled.select`
+  padding: 0.75rem 1rem;
+  border: 1.5px solid #ccc;
+  border-radius: 8px;
+  font-size: 1rem;
+  background: #fff;
+  cursor: pointer;
+
+  &:focus {
+    outline: none;
+    border-color: #FF6922;
+  }
+`;
+
+const SectionTitle = styled.h3`
+  color: #48cae4;
+  font-size: 1rem;
+  margin: 1rem 0 0.5rem;
+  border-bottom: 1px solid #e0e0e0;
+  padding-bottom: 0.4rem;
+`;
+
+const SubmitButton = styled.button`
+  width: 100%;
+  background-color: #FF6922;
+  color: #fff;
+  padding: 0.85rem;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  margin-top: 0.5rem;
+  transition: background-color 0.2s;
+
+  &:hover {
+    background-color: #e55a10;
+  }
+
+  &:disabled {
+    background-color: #ccc;
+    cursor: not-allowed;
+  }
+`;
+
+const SecondaryButton = styled(Link)`
+  display: block;
+  text-align: center;
+  margin-top: 0.8rem;
+  padding: 0.75rem;
+  border: 1.5px solid #0E2E50;
+  border-radius: 8px;
+  color: #0E2E50;
+  font-weight: 600;
+  text-decoration: none;
+  transition: all 0.2s;
+
+  &:hover {
+    background-color: #0E2E50;
+    color: #fff;
+  }
+`;
+
+const ErrorMessage = styled.p`
+  color: #e53935;
+  background: #fdecea;
+  border-radius: 6px;
+  padding: 0.6rem 1rem;
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+  text-align: center;
+`;
+
+const FieldError = styled.span`
+  color: #e53935;
+  font-size: 0.8rem;
+  margin-top: 0.2rem;
+`;
 
 export const SignUpForm = () => {
-    const [firstName, setFirstName] = useState('');
-    const [lastName, setLastName] = useState('');
-    const [email, setEmail] = useState('');
-    const [address, setAddress] = useState('');
-    const [password, setPassword] = useState('');
-    const [confirmPassword, setConfirmPassword] = useState('');
-    const [birthdate, setBirthdate] = useState('');
-    const [phoneNumber, setPhoneNumber] = useState('');
-    const [dni, setDNI] = useState('');
-    const [userType, setUserType] = useState('cliente');
-    const [isRegistered, setIsRegistered] = useState(false);
+  const navigate = useNavigate();
+  const [userType, setUserType] = useState('cliente');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
 
-    // Campos adicionales para profesionales
-    const [registrationNumber, setRegistrationNumber] = useState('');
-    const [specialty, setSpecialty] = useState('');
+  const [form, setForm] = useState({
+    firstName: '',
+    lastName: '',
+    age: '',
+    email: '',
+    password: '',
+    confirmPassword: '',
+    address: '',
+    birthDate: '',
+    phoneNumber: '',
+    dni: '',
+    userName: '',
+    registrationNumber: '',
+    specialty: '',
+    yearsOfExperience: '',
+  });
 
+  const [fieldErrors, setFieldErrors] = useState({});
 
-    const handleSubmit = async (e) => {
-        e.preventDefault();
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+    setFieldErrors({ ...fieldErrors, [e.target.name]: '' });
+  };
 
-        const userData = {
-            firstName: firstName,
-            lastName: lastName,
-            email: email,
-            address: address,
-            password: password,
-            birthDate: new Date(birthdate),
-            phoneNumber: phoneNumber,
-            dni: dni,
-            userType: userType,
-            registrationNumber: registrationNumber,
-            specialty: specialty,
-        };
+  const validate = () => {
+    const errors = {};
+    if (!form.firstName) errors.firstName = 'Requerido';
+    if (!form.lastName) errors.lastName = 'Requerido';
+    if (!form.email) errors.email = 'Requerido';
+    if (!form.password) errors.password = 'Requerido';
+    if (form.password !== form.confirmPassword) errors.confirmPassword = 'Las contraseñas no coinciden';
+    if (!form.dni) errors.dni = 'Requerido';
+    if (!form.userName) errors.userName = 'Requerido';
+    if (userType === 'profesional' && !form.specialty) errors.specialty = 'Requerido';
+    return errors;
+  };
 
-        try {
-            let response;
-            if (userType === 'cliente') {
-                response = await fetch('http://localhost:3000/add-client', {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                    },
-                    body: JSON.stringify(userData),
-                });
-            } else if (userType === 'profesional') {
-                response = await fetch('http://localhost:3000/add-professional', {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                    },
-                    body: JSON.stringify(userData),
-                });
-            }
-            const data = await response.json();
-            if (response.ok) {
-                setIsRegistered(true);
-                window.alert(data.message);
-                window.location.href = "/";
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
 
-            } else {
-                window.alert(data.message);
-            }
-        } catch (error) {
-            console.error('Error al registrarse:', error);
-        }
+    const errors = validate();
+    if (Object.keys(errors).length > 0) {
+      setFieldErrors(errors);
+      return;
+    }
+
+    setLoading(true);
+
+    const payload = {
+      firstName: form.firstName,
+      lastName: form.lastName,
+      age: Number(form.age),
+      email: form.email,
+      password: form.password,
+      address: form.address,
+      birthDate: form.birthDate,
+      phoneNumber: Number(form.phoneNumber),
+      dni: Number(form.dni),
+      userName: form.userName,
+      ...(userType === 'profesional' && {
+        registrationNumber: Number(form.registrationNumber),
+        specialty: form.specialty,
+        yearsOfExperience: Number(form.yearsOfExperience),
+      }),
     };
 
-    return (
-        <div className='container1 box'>
-            {isRegistered ? (
-                <Link to="/App" />
-            ) : (
-                <form onSubmit={handleSubmit}>
-                    <h2>Registrarse</h2>
-                    <div>
-                        <label htmlFor="firstName">Nombre</label>
-                        <input
-                            type="text"
-                            id="firstName"
-                            value={firstName}
-                            onChange={(e) => setFirstName(e.target.value)}
-                        />
-                    </div>
-                    <div>
-                        <label htmlFor="lastName">Apellido</label>
-                        <input
-                            type="text"
-                            id="lastName"
-                            value={lastName}
-                            onChange={(e) => setLastName(e.target.value)}
-                        />
-                    </div>
-                    <div>
-                        <label htmlFor="address">Dirección</label>
-                        <input
-                            type="text"
-                            id="address"
-                            value={address}
-                            onChange={(e) => setAddress(e.target.value)}
-                        />
-                    </div>
-                    <div>
-                        <label htmlFor="birthdate">Fecha de Nacimiento</label>
-                        <input
-                            type="date"
-                            id="birthdate"
-                            value={birthdate}
-                            onChange={(e) => setBirthdate(e.target.value)}
-                        />
-                    </div>
-                    <div>
-                        <label htmlFor="phoneNumber">Número de Teléfono</label>
-                        <input
-                            type="tel"
-                            id="phoneNumber"
-                            value={phoneNumber}
-                            onChange={(e) => setPhoneNumber(e.target.value)}
-                        />
-                    </div>
-                    <div>
-                        <label htmlFor="dni">DNI</label>
-                        <input
-                            type="text"
-                            id="dni"
-                            value={dni}
-                            onChange={(e) => setDNI(e.target.value)}
-                        />
-                    </div>
-                    <div>
-                        <label htmlFor="userType">Tipo de Usuario:</label>
-                        <select
-                            id="userType"
-                            value={userType}
-                            onChange={(e) => setUserType(e.target.value)}
-                        >
-                            <option value="cliente">Cliente</option>
-                            <option value="profesional">Profesional</option>
-                        </select>
-                    </div>
-                    {/* Campos adicionales para profesionales */}
-                    {userType === 'profesional' && (
-                        <div>
-                            <div>
-                                <label htmlFor="registrationNumber">Número de Matrícula</label>
-                                <input
-                                    type="text"
-                                    id="registrationNumber"
-                                    value={registrationNumber}
-                                    onChange={(e) => setRegistrationNumber(e.target.value)}
-                                />
-                            </div>
-                            <div>
-                                <label htmlFor="specialty">Especialidad</label>
-                                <select
-                                    id="specialty"
-                                    value={specialty}
-                                    onChange={(e) => setSpecialty(e.target.value)}
-                                >
-                                    <option value="">Seleccionar Especialidad</option>
-                                    <option value="Plomero">Plomero</option>
-                                    <option value="Electricista">Electricista</option>
-                                    <option value="Carpintero">Carpintero</option>
-                                    <option value="Albañil">Albañil</option>
-                                    <option value="Jardinero">Jardinero</option>
-                                </select>
-                            </div>
-                        </div>
-                    )}
-                    <div>
-                        <label htmlFor="email">Correo Electrónico</label>
-                        <input
-                            type="email"
-                            id="email"
-                            value={email}
-                            onChange={(e) => setEmail(e.target.value)}
-                        />
-                    </div>
-                    <div>
-                        <label htmlFor="password">Contraseña</label>
-                        <input
-                            type="password"
-                            id="password"
-                            value={password}
-                            onChange={(e) => setPassword(e.target.value)}
-                        />
-                    </div>
-                    <div>
-                        <label htmlFor="confirmPassword">Confirmar Contraseña</label>
-                        <input
-                            type="password"
-                            id="confirmPassword"
-                            value={confirmPassword}
-                            onChange={(e) => setConfirmPassword(e.target.value)}
-                        />
-                    </div>
-                    <button type="submit">Registrarse</button>
-                    <Link to="/login"><button type="submit">Volver</button></Link>
-                </form>
-            )}
-        </div>
-    );
+    try {
+      const endpoint = userType === 'cliente' ? '/add-client' : '/add-professional';
+      const response = await fetch(`http://localhost:3000${endpoint}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+
+      const data = await response.json();
+
+      if (response.ok) {
+        if (data.token) {
+          localStorage.setItem('token', data.token);
+          localStorage.setItem('user', JSON.stringify(data.client || data.professional));
+        }
+        navigate('/login');
+      } else {
+        setError(data.message);
+      }
+    } catch (err) {
+      setError('Error de conexión. Intente nuevamente.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Wrapper>
+      <Card>
+        <Title>Crear cuenta</Title>
+
+        {error && <ErrorMessage>{error}</ErrorMessage>}
+
+        <form onSubmit={handleSubmit}>
+          <FormGroup>
+            <Label htmlFor="userType">Tipo de cuenta</Label>
+            <Select
+              id="userType"
+              value={userType}
+              onChange={(e) => setUserType(e.target.value)}
+            >
+              <option value="cliente">Cliente</option>
+              <option value="profesional">Profesional</option>
+            </Select>
+          </FormGroup>
+
+          <SectionTitle>Datos personales</SectionTitle>
+
+          <Row>
+            <FormGroup>
+              <Label htmlFor="firstName">Nombre</Label>
+              <Input
+                type="text"
+                id="firstName"
+                name="firstName"
+                value={form.firstName}
+                onChange={handleChange}
+                placeholder="Juan"
+                $error={fieldErrors.firstName}
+              />
+              {fieldErrors.firstName && <FieldError>{fieldErrors.firstName}</FieldError>}
+            </FormGroup>
+
+            <FormGroup>
+              <Label htmlFor="lastName">Apellido</Label>
+              <Input
+                type="text"
+                id="lastName"
+                name="lastName"
+                value={form.lastName}
+                onChange={handleChange}
+                placeholder="Perez"
+                $error={fieldErrors.lastName}
+              />
+              {fieldErrors.lastName && <FieldError>{fieldErrors.lastName}</FieldError>}
+            </FormGroup>
+          </Row>
+
+          <Row>
+            <FormGroup>
+              <Label htmlFor="dni">DNI</Label>
+              <Input
+                type="number"
+                id="dni"
+                name="dni"
+                value={form.dni}
+                onChange={handleChange}
+                placeholder="12345678"
+                $error={fieldErrors.dni}
+              />
+              {fieldErrors.dni && <FieldError>{fieldErrors.dni}</FieldError>}
+            </FormGroup>
+
+            <FormGroup>
+              <Label htmlFor="age">Edad</Label>
+              <Input
+                type="number"
+                id="age"
+                name="age"
+                value={form.age}
+                onChange={handleChange}
+                placeholder="25"
+              />
+            </FormGroup>
+          </Row>
+
+          <Row>
+            <FormGroup>
+              <Label htmlFor="birthDate">Fecha de nacimiento</Label>
+              <Input
+                type="date"
+                id="birthDate"
+                name="birthDate"
+                value={form.birthDate}
+                onChange={handleChange}
+              />
+            </FormGroup>
+
+            <FormGroup>
+              <Label htmlFor="phoneNumber">Teléfono</Label>
+              <Input
+                type="tel"
+                id="phoneNumber"
+                name="phoneNumber"
+                value={form.phoneNumber}
+                onChange={handleChange}
+                placeholder="2615551234"
+              />
+            </FormGroup>
+          </Row>
+
+          <FormGroup>
+            <Label htmlFor="address">Dirección</Label>
+            <Input
+              type="text"
+              id="address"
+              name="address"
+              value={form.address}
+              onChange={handleChange}
+              placeholder="Mendoza, Argentina"
+            />
+          </FormGroup>
+
+          <SectionTitle>Cuenta</SectionTitle>
+
+          <FormGroup>
+            <Label htmlFor="userName">Nombre de usuario</Label>
+            <Input
+              type="text"
+              id="userName"
+              name="userName"
+              value={form.userName}
+              onChange={handleChange}
+              placeholder="jperez"
+              $error={fieldErrors.userName}
+            />
+            {fieldErrors.userName && <FieldError>{fieldErrors.userName}</FieldError>}
+          </FormGroup>
+
+          <FormGroup>
+            <Label htmlFor="email">Correo electrónico</Label>
+            <Input
+              type="email"
+              id="email"
+              name="email"
+              value={form.email}
+              onChange={handleChange}
+              placeholder="tu@email.com"
+              $error={fieldErrors.email}
+            />
+            {fieldErrors.email && <FieldError>{fieldErrors.email}</FieldError>}
+          </FormGroup>
+
+          <Row>
+            <FormGroup>
+              <Label htmlFor="password">Contraseña</Label>
+              <Input
+                type="password"
+                id="password"
+                name="password"
+                value={form.password}
+                onChange={handleChange}
+                placeholder="••••••••"
+                $error={fieldErrors.password}
+              />
+              {fieldErrors.password && <FieldError>{fieldErrors.password}</FieldError>}
+            </FormGroup>
+
+            <FormGroup>
+              <Label htmlFor="confirmPassword">Confirmar contraseña</Label>
+              <Input
+                type="password"
+                id="confirmPassword"
+                name="confirmPassword"
+                value={form.confirmPassword}
+                onChange={handleChange}
+                placeholder="••••••••"
+                $error={fieldErrors.confirmPassword}
+              />
+              {fieldErrors.confirmPassword && <FieldError>{fieldErrors.confirmPassword}</FieldError>}
+            </FormGroup>
+          </Row>
+
+          {userType === 'profesional' && (
+            <>
+              <SectionTitle>Datos profesionales</SectionTitle>
+
+              <FormGroup>
+                <Label htmlFor="specialty">Especialidad</Label>
+                <Select
+                  id="specialty"
+                  name="specialty"
+                  value={form.specialty}
+                  onChange={handleChange}
+                >
+                  <option value="">Seleccionar especialidad</option>
+                  <option value="Plomero">Plomero</option>
+                  <option value="Electricista">Electricista</option>
+                  <option value="Carpintero">Carpintero</option>
+                  <option value="Albanil">Albañil</option>
+                  <option value="Jardinero">Jardinero</option>
+                  <option value="Gasista">Gasista</option>
+                  <option value="Pintor">Pintor</option>
+                  <option value="Cerrajero">Cerrajero</option>
+                  <option value="Soldador">Soldador</option>
+                </Select>
+                {fieldErrors.specialty && <FieldError>{fieldErrors.specialty}</FieldError>}
+              </FormGroup>
+
+              <Row>
+                <FormGroup>
+                  <Label htmlFor="registrationNumber">Número de matrícula</Label>
+                  <Input
+                    type="number"
+                    id="registrationNumber"
+                    name="registrationNumber"
+                    value={form.registrationNumber}
+                    onChange={handleChange}
+                    placeholder="12345"
+                  />
+                </FormGroup>
+
+                <FormGroup>
+                  <Label htmlFor="yearsOfExperience">Años de experiencia</Label>
+                  <Input
+                    type="number"
+                    id="yearsOfExperience"
+                    name="yearsOfExperience"
+                    value={form.yearsOfExperience}
+                    onChange={handleChange}
+                    placeholder="5"
+                  />
+                </FormGroup>
+              </Row>
+            </>
+          )}
+
+          <SubmitButton type="submit" disabled={loading}>
+            {loading ? 'Registrando...' : 'Crear cuenta'}
+          </SubmitButton>
+
+          <SecondaryButton to="/login">¿Ya tenés cuenta? Iniciá sesión</SecondaryButton>
+        </form>
+      </Card>
+    </Wrapper>
+  );
 };

--- a/frontend/src/components/SignUpForm/SignUpForm.jsx
+++ b/frontend/src/components/SignUpForm/SignUpForm.jsx
@@ -20,6 +20,12 @@ const Card = styled.div`
   max-width: 480px;
 `;
 
+const Logo = styled.img`
+  display: block;
+  margin: 0 auto 1.5rem;
+  width: 160px;
+`;
+
 const Title = styled.h2`
   color: #0E2E50;
   text-align: center;
@@ -240,6 +246,7 @@ export const SignUpForm = () => {
   return (
     <Wrapper>
       <Card>
+        <Logo src="/img/tuoficio_logo.png" alt="Tu Oficio" />
         <Title>Crear cuenta</Title>
 
         {error && <ErrorMessage>{error}</ErrorMessage>}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,10 @@
         "backend",
         "frontend"
       ],
+      "dependencies": {
+        "leaflet": "^1.9.4",
+        "react-leaflet": "^4.2.1"
+      },
       "devDependencies": {
         "concurrently": "^9.2.1"
       }
@@ -1336,10 +1340,12 @@
       "dependencies": {
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/user-event": "^13.5.0",
+        "leaflet": "^1.9.4",
         "postcss": "^8.4.31",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^4.11.0",
+        "react-leaflet": "^4.2.1",
         "react-modal": "^3.16.1",
         "react-router-dom": "^6.18.0",
         "react-scripts": "^5.0.1",
@@ -1349,6 +1355,7 @@
       },
       "devDependencies": {
         "@testing-library/react": "^14.0.0",
+        "@types/leaflet": "^1.9.21",
         "jest": "^27.5.1"
       }
     },
@@ -3443,7 +3450,7 @@
       "version": "0.8.0",
       "resolved": "https://npm.artifacts.furycloud.io/repository/all/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
       "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 12"
@@ -3453,7 +3460,7 @@
       "version": "0.7.0",
       "resolved": "https://npm.artifacts.furycloud.io/repository/all/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
       "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-consumer": "0.8.0"
@@ -5340,6 +5347,17 @@
         "node": ">= 12"
       }
     },
+    "node_modules/@react-leaflet/core": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.2",
       "resolved": "https://npm.artifacts.furycloud.io/repository/all/@remix-run/router/-/router-1.23.2.tgz",
@@ -5715,26 +5733,6 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.1",
-      "resolved": "https://npm.artifacts.furycloud.io/repository/all/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "5.17.0",
       "resolved": "https://npm.artifacts.furycloud.io/repository/all/@testing-library/jest-dom/-/jest-dom-5.17.0.tgz",
@@ -5861,28 +5859,28 @@
       "version": "1.0.12",
       "resolved": "https://npm.artifacts.furycloud.io/repository/all/@tsconfig/node10/-/node10-1.0.12.tgz",
       "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://npm.artifacts.furycloud.io/repository/all/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://npm.artifacts.furycloud.io/repository/all/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://npm.artifacts.furycloud.io/repository/all/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
@@ -5900,6 +5898,7 @@
       "version": "5.0.4",
       "resolved": "https://npm.artifacts.furycloud.io/repository/all/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/babel__core": {
@@ -6060,6 +6059,13 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://npm.artifacts.furycloud.io/repository/all/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -6179,6 +6185,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.21",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
+      "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
     "node_modules/@types/methods": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
@@ -6226,14 +6242,6 @@
       "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
       "license": "MIT"
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://npm.artifacts.furycloud.io/repository/all/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@types/q": {
       "version": "1.5.8",
       "resolved": "https://npm.artifacts.furycloud.io/repository/all/@types/q/-/q-1.5.8.tgz",
@@ -6251,18 +6259,6 @@
       "resolved": "https://npm.artifacts.furycloud.io/repository/all/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "license": "MIT"
-    },
-    "node_modules/@types/react": {
-      "version": "18.3.28",
-      "resolved": "https://npm.artifacts.furycloud.io/repository/all/@types/react/-/react-18.3.28.tgz",
-      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.2.2"
-      }
     },
     "node_modules/@types/react-dom": {
       "version": "18.3.7",
@@ -9127,7 +9123,7 @@
       "version": "1.1.1",
       "resolved": "https://npm.artifacts.furycloud.io/repository/all/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -9830,7 +9826,7 @@
       "version": "4.0.4",
       "resolved": "https://npm.artifacts.furycloud.io/repository/all/diff/-/diff-4.0.4.tgz",
       "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -15694,6 +15690,12 @@
         "shell-quote": "^1.8.3"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://npm.artifacts.furycloud.io/repository/all/leven/-/leven-3.1.0.tgz",
@@ -15882,6 +15884,7 @@
       "version": "1.5.0",
       "resolved": "https://npm.artifacts.furycloud.io/repository/all/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "lz-string": "bin/bin.js"
@@ -15927,7 +15930,7 @@
       "version": "1.3.6",
       "resolved": "https://npm.artifacts.furycloud.io/repository/all/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/makeerror": {
@@ -18730,6 +18733,20 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "license": "MIT"
     },
+    "node_modules/react-leaflet": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-4.2.1.tgz",
+      "integrity": "sha512-p9chkvhcKrWn/H/1FFeVSqLdReGwn2qmiobOQGO3BifX+/vV/39qhY8dGqbdcPh1e6jxh/QHriLXr7a4eLFK4Q==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^2.1.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://npm.artifacts.furycloud.io/repository/all/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
@@ -20971,23 +20988,6 @@
         }
       }
     },
-    "node_modules/tailwindcss/node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://npm.artifacts.furycloud.io/repository/all/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/tapable": {
       "version": "2.3.0",
       "resolved": "https://npm.artifacts.furycloud.io/repository/all/tapable/-/tapable-2.3.0.tgz",
@@ -21325,7 +21325,7 @@
       "version": "10.7.0",
       "resolved": "https://npm.artifacts.furycloud.io/repository/all/ts-node/-/ts-node-10.7.0.tgz",
       "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.7.0",
@@ -21369,7 +21369,7 @@
       "version": "8.3.5",
       "resolved": "https://npm.artifacts.furycloud.io/repository/all/acorn-walk/-/acorn-walk-8.3.5.tgz",
       "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.11.0"
@@ -21382,7 +21382,7 @@
       "version": "4.1.3",
       "resolved": "https://npm.artifacts.furycloud.io/repository/all/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tsconfig-paths": {
@@ -21829,6 +21829,7 @@
       "version": "4.9.5",
       "resolved": "https://npm.artifacts.furycloud.io/repository/all/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -22099,7 +22100,7 @@
       "version": "3.0.1",
       "resolved": "https://npm.artifacts.furycloud.io/repository/all/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
@@ -23071,7 +23072,7 @@
       "version": "3.1.1",
       "resolved": "https://npm.artifacts.furycloud.io/repository/all/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/package.json
+++ b/package.json
@@ -22,5 +22,9 @@
   },
   "devDependencies": {
     "concurrently": "^9.2.1"
+  },
+  "dependencies": {
+    "leaflet": "^1.9.4",
+    "react-leaflet": "^4.2.1"
   }
 }


### PR DESCRIPTION
## Summary
- Refactor LoginForm and SignUpForm with styled-components and inline validation
- Add JWT storage in localStorage on login/register
- Refactor SearchResults with real API data, interactive Leaflet map and geocoding
- Add WhatsApp + Ver perfil buttons in map popup and cards
- Add ProfessionalProfile page with reviews
- Add Review entity and endpoints (GET/POST /professionals/:id/reviews)
- Update Navbar to show logged-in user (avatar, name, role badge, logout)
- Allow admin to login via client or professional endpoints
- Update Recommend section with real data from API (4 tabs)
- Update Hero subtitle text and fix search input width
- Add seed with 70 professionals and reviews

## Test plan
- [ ] Login with admin@tuoficio.com / admin123 (client or professional option)
- [ ] Verify Navbar shows user info and logout button
- [ ] Search professionals and verify map markers
- [ ] Click Ver perfil and verify reviews appear
- [ ] Check Recommend section tabs load real data

🤖 Generated with [Claude Code](https://claude.com/claude-code)